### PR TITLE
Updates to shellcode development tutorials

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A collection of awesome penetration testing resources
 
 - [Online Resources](#online-resources)
   - [Penetration Testing Resources](#penetration-testing-resources)
-  - [Shellcode development](#shellcode-development)
+  - [Exploit development](#exploit-development)
   - [Social Engineering Resources](#social-engineering-resources)
   - [Lock Picking Resources](#lock-picking-resources)
 - [Tools](#tools)
@@ -48,8 +48,8 @@ A collection of awesome penetration testing resources
 * [PTES](http://www.pentest-standard.org/) - Penetration Testing Execution Standard
 * [OWASP](https://www.owasp.org/index.php/Main_Page) - Open Web Application Security Project 
 
-#### Shellcode development
-* [Shellcode Tutorials](http://www.projectshellcode.com/?q=node/12) - Tutorials on how to write shellcode
+#### Exploit development
+* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to write shellcode
 * [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database
 
 #### Social Engineering Resources

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A collection of awesome penetration testing resources
 * [OWASP](https://www.owasp.org/index.php/Main_Page) - Open Web Application Security Project 
 
 #### Exploit development
-* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to write shellcode
+* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to develop exploits
 * [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database
 
 #### Social Engineering Resources


### PR DESCRIPTION
- Replaced broken link to shellcode development tutorial.
- In my opinion the title 'Exploit development' would be more appropriate as shellcodes are generally included in exploits.