### PR TITLE
"Python tools for penetration testers" url change

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,7 +333,7 @@ A collection of awesome penetration testing resources
 * [JavaScript Programming](https://github.com/sorrycc/awesome-javascript) - In-browser development and scripting
 * [Node.js Programming by @sindresorhus](https://github.com/sindresorhus/awesome-nodejs) - JavaScript in command-line
 * [Node.js Programming by @vndmtrx](https://github.com/vndmtrx/awesome-nodejs) -  JavaScript in command-line
-* [Python tools for penetration testers](http://www.dirk-loss.de/python-tools.htm) - Lots of pentesting tools are written in Python
+* [Python tools for penetration testers](https://github.com/dloss/python-pentest-tools) - Lots of pentesting tools are written in Python
 * [Python Programming by @svaksha](https://github.com/svaksha/pythonidae) - General Python programming
 * [Python Programming by @vinta](https://github.com/vinta/awesome-python) - General Python programming
 * [Android Security](https://github.com/ashishb/android-security-awesome) - A collection of android security related resources


### PR DESCRIPTION
Python tools for penetration testers has moved to https://github.com/dloss/python-pentest-tools