### PR TITLE
Add routersploit in penetration testing tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ A collection of awesome penetration testing resources
 * [faraday](https://github.com/infobyte/faraday) - Collaborative Penetration Test and Vulnerability Management Platform
 * [evilgrade](https://github.com/infobyte/evilgrade) - The update explotation framework
 * [commix](https://github.com/stasinopoulos/commix) - Automated All-in-One OS Command Injection and Exploitation Tool
+* [routersploit](https://github.com/reverse-shell/routersploit) - Automated penetration testing software for router
 
 #### Docker for Penetration Testing
 * `docker pull kalilinux/kali-linux-docker` [official Kali Linux](https://hub.docker.com/r/kalilinux/kali-linux-docker/)


### PR DESCRIPTION
Routersploit is a tool similar to metasploit, but adapt to router exploitation. The project is really active.