### PR TITLE
Removed usertaken/archlinux-pentest-lxde docker (404)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,6 @@ A collection of awesome penetration testing resources
 * `docker pull hmlio/vaas-cve-2014-6271` - [Vulnerability as a service: Shellshock](https://hub.docker.com/r/hmlio/vaas-cve-2014-6271/)
 * `docker pull hmlio/vaas-cve-2014-0160` - [Vulnerability as a service: Heartbleed](https://hub.docker.com/r/hmlio/vaas-cve-2014-0160/)
 * `docker pull opendns/security-ninjas` - [Security Ninjas](https://hub.docker.com/r/opendns/security-ninjas/)
-* `docker pull usertaken/archlinux-pentest-lxde` - [Arch Linux Penetration Tester](https://hub.docker.com/r/usertaken/archlinux-pentest-lxde/)
 * `docker pull diogomonica/docker-bench-security` - [Docker Bench for Security](https://hub.docker.com/r/diogomonica/docker-bench-security/)
 * `docker pull ismisepaul/securityshepherd` - [OWASP Security Shepherd](https://hub.docker.com/r/ismisepaul/securityshepherd/)
 * `docker pull danmx/docker-owasp-webgoat` - [OWASP WebGoat Project docker image](https://hub.docker.com/r/danmx/docker-owasp-webgoat/)


### PR DESCRIPTION
Doesn't seem to be available anymore
https://hub.docker.com/r/usertaken/archlinux-pentest-lxde/


[ldionmarcil:~]$ sudo docker pull usertaken/archlinux-pentest-lxde
Using default tag: latest
Pulling repository docker.io/usertaken/archlinux-pentest-lxde
Error: image usertaken/archlinux-pentest-lxde not found