### PR TITLE
add binary ninja

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,6 +233,7 @@ A collection of awesome penetration testing resources
 * [Evan's Debugger](http://www.codef00.com/projects#debugger) - OllyDbg-like debugger for Linux
 * [Medusa disassembler](https://github.com/wisk/medusa) - An open source interactive disassembler
 * [plasma](https://github.com/joelpx/plasma) - Interactive disassembler for x86/ARM/MIPS. Generates indented pseudo-code with colored syntax code.
+* [Binary Ninja](https://binary.ninja/) - A reverse engineering platform for Windows, Mac and Linux
 
 #### CTF Tools
 * [Pwntools](https://github.com/Gallopsled/pwntools) - CTF framework for use in CTFs


### PR DESCRIPTION
Binary Ninja is a reverse engineering platform that runs on Windows, Mac, Linux and supports x86/x64, ARM, MIPS, 6502.

https://binary.ninja