### PR TITLE
add OSINT-Framework to OSInt List

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,7 @@ A collection of awesome penetration testing resources
 * [snitch](https://github.com/Smaash/snitch) - information gathering via dorks
 * [GooDork](https://github.com/k3170makan/GooDork) - Command line go0gle dorking tool
 * [OSINT Framework](http://osintframework.com/) - Collection of various OSInt tools broken out by category.
+* [Intel Techniques](https://inteltechniques.com/menu.html) - A collection of OSINT tools. Menu on the left can be used to navigate through the categories.
 
 #### Anonymity Tools
 * [Tor](https://www.torproject.org/) - The free software for enabling onion routing online anonymity

--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ A collection of awesome penetration testing resources
 * [Google-dorks](https://github.com/JohnTroony/Google-dorks) - Common google dorks and others you prolly don't know
 * [snitch](https://github.com/Smaash/snitch) - information gathering via dorks
 * [GooDork](https://github.com/k3170makan/GooDork) - Command line go0gle dorking tool
+* [OSINT Framework](http://osintframework.com/) - Collection of various OSInt tools broken out by category.
 
 #### Anonymity Tools
 * [Tor](https://www.torproject.org/) - The free software for enabling onion routing online anonymity


### PR DESCRIPTION
adding OSINT-Framework (http://osintframework.com/) and Intel Techniques (https://inteltechniques.com/menu.html) to OSINT List