### PR TITLE
Added "File Format Analysis Tools" section (+3 tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,11 @@ A collection of awesome penetration testing resources
 * [HexEdit.js](https://hexed.it) - Browser-based hex editing
 * [Hexinator](https://hexinator.com/) (commercial) - World's finest Hex Editor
 
+#### File Format Analysis Tools
+* [Kaitai Struct](http://kaitai.io/) - File formats and network protocols dissection language and web IDE, generating parsers in C++, C#, Java, JavaScript, Perl, PHP, Python, Ruby
+* [Veles](https://codisec.com/veles/) - Binary data visualization and analysis tool
+* [Hachoir](http://hachoir3.readthedocs.io/) - Python library to view and edit a binary stream as tree of fields and tools for metadata extraction
+
 #### Crackers
 * [John the Ripper](http://www.openwall.com/john/) - Fast password cracker
 * [Hashcat](http://hashcat.net/hashcat/) - The more fast hash cracker


### PR DESCRIPTION
I'd like to propose adding "File Format Analysis Tools" section that goes somewhere close to "Hex Editors", but serves a slightly different purpose.

There's a few nice tools that allow us to dissect, analyze, visualize and potentially work on reverse engineering of arbitrary binary file formats. This is generally an important part of any large pentest project, especially if we're working on some closer-to-hardware stuff, where the data of the systems we're trying to attack is not all human-readable JSON and XML, but laid out in some (usually proprietary) file formats.

Partially, it can be done with advanced hex editors, such as Hexinator and/or 010 Editor, but it many cases it's more useful to access that data programmatically. As a start of category, I've chosen 3 most awesome projects I know in that department: Kaitai Struct, Veles and Hachoir.