### PR TITLE
Retitle "Crackers" to "Hash Cracking Tools" and add CeWL project.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A collection of awesome penetration testing resources
   - [SSL Analysis Tools](#ssl-analysis-tools)
   - [Web Exploitation](#web-exploitation)
   - [Hex Editors](#hex-editors)
-  - [Crackers](#crackers)
+  - [Hash Cracking Tools](#hash-cracking-tools)
   - [Windows Utils](#windows-utils)
   - [Linux Utils](#linux-utils)
   - [DDoS Tools](#ddos-tools)
@@ -208,9 +208,10 @@ A collection of awesome penetration testing resources
 * [Veles](https://codisec.com/veles/) - Binary data visualization and analysis tool
 * [Hachoir](http://hachoir3.readthedocs.io/) - Python library to view and edit a binary stream as tree of fields and tools for metadata extraction
 
-#### Crackers
+#### Hash Cracking Tools
 * [John the Ripper](http://www.openwall.com/john/) - Fast password cracker
 * [Hashcat](http://hashcat.net/hashcat/) - The more fast hash cracker
+* [CeWL](https://digi.ninja/projects/cewl.php) - Generates custom wordlists by spidering a target's website and collecting unique words
 
 #### Windows Utils
 * [Sysinternals Suite](https://technet.microsoft.com/en-us/sysinternals/bb842062) - The Sysinternals Troubleshooting Utilities


### PR DESCRIPTION
I wanted to add the custom wordlist generator, CeWL, but there was no good section in which to put it, so I generalized the "Crackers" section to be "Hash Cracking Tools" since this is both more consistent with the other section headings that already exist and also provides a space where cracking utilities, beyond just hashing tools, can be sensibly added.