### PR TITLE
Group OSINT collections (rather than tools) in their own section, add a new collection, fix link for HackThisSite.org.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A collection of awesome penetration testing resources
 - [Online Resources](#online-resources)
   - [Penetration Testing Resources](#penetration-testing-resources)
   - [Exploit development](#exploit-development)
+  - [Open Sources Intelligence (OSINT) Resources](#osint-resources)
   - [Social Engineering Resources](#social-engineering-resources)
   - [Lock Picking Resources](#lock-picking-resources)
   - [Operating Systems](#operating-systems)
@@ -67,6 +68,11 @@ A collection of awesome penetration testing resources
 * [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to develop exploits
 * [shellsploit](https://github.com/b3mb4m/shellsploit-framework) - New Generation Exploit Development Kit
 * [Voltron](https://github.com/snare/voltron) - A hacky debugger UI for hackers
+
+#### OSINT Resources
+* [OSINT Framework](http://osintframework.com/) - Collection of various OSInt tools broken out by category.
+* [Intel Techniques](https://inteltechniques.com/menu.html) - A collection of OSINT tools. Menu on the left can be used to navigate through the categories.
+* [NetBootcamp OSINT Tools](http://netbootcamp.org/osinttools/) - A collection of OSINT links and custom Web interfaces to other services such as [Facebook Graph Search](http://netbootcamp.org/facebook.html) and [various paste sites](http://netbootcamp.org/pastesearch.html).
 
 #### Social Engineering Resources
 * [Social Engineering Framework](http://www.social-engineer.org/framework/general-discussion/) - An information resource for social engineers
@@ -258,6 +264,9 @@ A collection of awesome penetration testing resources
 * [creepy](https://github.com/ilektrojohn/creepy) - A geolocation OSINT tool
 * [metagoofil](https://github.com/laramies/metagoofil) - Metadata harvester
 * [Google Hacking Database](https://www.exploit-db.com/google-hacking-database/) - a database of Google dorks; can be used for recon
+* [Google-dorks](https://github.com/JohnTroony/Google-dorks) - Common google dorks and others you prolly don't know
+* [GooDork](https://github.com/k3170makan/GooDork) - Command line go0gle dorking tool
+* [dork-cli](https://github.com/jgor/dork-cli) - Command-line Google dork tool.
 * [Censys](https://www.censys.io/) - Collects data on hosts and websites through daily ZMap and ZGrab scans
 * [Shodan](https://www.shodan.io/) - Shodan is the world's first search engine for Internet-connected devices
 * [recon-ng](https://bitbucket.org/LaNMaSteR53/recon-ng) - A full-featured Web Reconnaissance framework written in Python
@@ -265,16 +274,11 @@ A collection of awesome penetration testing resources
 * [vcsmap](https://github.com/melvinsh/vcsmap) - A plugin-based tool to scan public version control systems for sensitive information
 * [Spiderfoot](http://www.spiderfoot.net/) - multi-source OSINT automation tool with a Web UI and report visualizations
 * [BinGoo](https://github.com/Hood3dRob1n/BinGoo) - A Linux bash based Bing and Google Dorking Tool
-* [dork-cli](https://github.com/jgor/dork-cli) - Command-line Google dork tool.
 * [fast-recon](https://github.com/DanMcInerney/fast-recon) - Does some google dorks against a domain
-* [Google-dorks](https://github.com/JohnTroony/Google-dorks) - Common google dorks and others you prolly don't know
 * [snitch](https://github.com/Smaash/snitch) - information gathering via dorks
-* [GooDork](https://github.com/k3170makan/GooDork) - Command line go0gle dorking tool
 * [Sn1per](https://github.com/1N3/Sn1per) - Automated Pentest Recon Scanner
 * [Threat Crowd](https://www.threatcrowd.org/) - A search engine for threats
 * [Virus Total](https://www.virustotal.com/) - VirusTotal is a free service that analyzes suspicious files and URLs and facilitates the quick detection of viruses, worms, trojans, and all kinds of malware.
-* [OSINT Framework](http://osintframework.com/) - Collection of various OSInt tools broken out by category.
-* [Intel Techniques](https://inteltechniques.com/menu.html) - A collection of OSINT tools. Menu on the left can be used to navigate through the categories.
 * [DataSploit](https://github.com/upgoingstar/datasploit) - OSINT visualizer utilizing Shodan, Censys, Clearbit, EmailHunter, FullContact, and Zoomeye behind the scenes.
 
 #### Anonymity Tools

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ A collection of awesome penetration testing resources
 * [RsaCtfTool](https://github.com/sourcekris/RsaCtfTool) - Decrypt data enciphered using weak RSA keys, and recover private keys from public keys using a variety of automated attacks
 
 #### Practice CTFs
-* [HackThisSite](hackthissite.org) - An online CTF with short challenges and clear progression
+* [HackThisSite](https://hackthissite.org/) - An online CTF with short challenges and clear progression
 * [HackMethod](https://hackmethod.com/) - An online CTF with short challenges and clear progression
 * [VulnHub](https://www.vulnhub.com/) - Hosts vulnerable VMs for downloading and hacking, founded by g0tmi1k
 


### PR DESCRIPTION
New section OSINT Resources for link-sites rather than actual tools.
    
This commit adds a new subsection under "Online Resources" called "OSInt Resources" and moves a few entries from the "OSInt Tools" section there. This is done because the OSInt Tools section has grown to expand entries that are not actually tools, but rather lists/collections of other tools. These OSINT resources are great, but are distinct from a single, installable, or otherwise immediately-usable tools.
    
This commit also adds a new such resource, NetBoomcamp.org's listing of OSINT tools and custom Web interfaces for some endpoints, like Facebook.