### PR TITLE
Fix `redsnarf` link, remove duplicate Empire entry, recategorize ZAP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ A collection of awesome penetration testing resources
 * [evilgrade](https://github.com/infobyte/evilgrade) - The update explotation framework
 * [commix](https://github.com/stasinopoulos/commix) - Automated All-in-One OS Command Injection and Exploitation Tool
 * [routersploit](https://github.com/reverse-shell/routersploit) - Automated penetration testing software for router
-* [redsnarf] (https://github.com/nccgroup/redsnarf) - Post-exploitation tool for grabbing credentials
+* [redsnarf](https://github.com/nccgroup/redsnarf) - Post-exploitation tool for grabbing credentials
 * [Bella](https://github.com/manwhoami/Bella) - Bella is a pure Python post-exploitation data mining & remote administration tool for Mac OS.
 
 #### Docker for Penetration Testing
@@ -138,7 +138,6 @@ A collection of awesome penetration testing resources
 * [Nessus](http://www.tenable.com/products/nessus-vulnerability-scanner) - Vulnerability, configuration, and compliance assessment
 * [Nikto](https://cirt.net/nikto2) - Web application vulnerability scanner
 * [OpenVAS](http://www.openvas.org/) - Open Source vulnerability scanner and manager
-* [OWASP Zed Attack Proxy](https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) - Penetration testing tool for web applications
 * [Secapps](https://secapps.com/) - Integrated web application security testing environment
 * [w3af](https://github.com/andresriancho/w3af) - Web application attack and audit framework
 * [Wapiti](http://wapiti.sourceforge.net/) - Web application vulnerability scanner
@@ -195,6 +194,7 @@ A collection of awesome penetration testing resources
 * [tls_prober](https://github.com/WestpointLtd/tls_prober) - fingerprint a server's SSL/TLS implementation
 
 #### Web exploitation
+* [OWASP Zed Attack Proxy](https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) - Penetration testing tool for web applications
 * [Burp Suite](https://portswigger.net/burp/) - An integrated platform for performing security testing of web applications
 * [autochrome](https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2017/march/autochrome/) - Easy to install a test browser with all the appropriate setting needed for web application testing with native Burp support, from NCCGroup.
 * [WPScan](https://wpscan.org/) - Black box WordPress vulnerability scanner
@@ -235,11 +235,10 @@ A collection of awesome penetration testing resources
 * [Windows Credentials Editor](http://www.ampliasecurity.com/research/windows-credentials-editor/) - security tool to list logon sessions and add, change, list and delete associated credentials
 * [mimikatz](http://blog.gentilkiwi.com/mimikatz) - Credentials extraction tool for Windows OS
 * [PowerSploit](https://github.com/PowerShellMafia/PowerSploit) - A PowerShell Post-Exploitation Framework
-* [Powershell Empire](https://www.powershellempire.com/) - A pure PowerShell post-exploitation agent built on cryptologically-secure communications and a flexible architecture
 * [Windows Exploit Suggester](https://github.com/GDSSecurity/Windows-Exploit-Suggester) - Detects potential missing patches on the target
 * [Responder](https://github.com/SpiderLabs/Responder) - A LLMNR, NBT-NS and MDNS poisoner
 * [Bloodhound](https://github.com/adaptivethreat/Bloodhound/wiki) - A graphical Active Directory trust relationship explorer
-* [Empire](https://github.com/PowerShellEmpire/Empire) - Empire is a pure PowerShell post-exploitation agent
+* [Empire](https://www.powershellempire.com/) - A pure PowerShell post-exploitation agent
 * [Fibratus](https://github.com/rabbitstack/fibratus) - Tool for exploration and tracing of the Windows kernel
 * [wePWNise](https://labs.mwrinfosecurity.com/tools/wepwnise/) - Generates architecture independent VBA code to be used in Office documents or templates and automates bypassing application control and exploit mitigation software
 


### PR DESCRIPTION
OWASP Zed Attack Proxy should be side-by-side with BurpSuite since both are specifically *HTTP* intercepting proxies. While they can be used for some lightweight "vulnerability scanning" (spidering, etc.) they are really more specifically *Web* tools.