### PR TITLE
Add "Physical Access Tools" section with three example tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ A collection of awesome penetration testing resources
   - [OSInt Tools](#osint-tools)
   - [Anonymity Tools](#anonymity-tools)
   - [Reverse Engineering Tools](#reverse-engineering-tools)
+  - [Physical Access Tools](#physical-access-tools)
   - [CTF Tools](#ctf-tools)
   - [Practice CTFs](#practice-ctfs)
 - [Books](#books)
@@ -298,6 +299,11 @@ A collection of awesome penetration testing resources
 * [plasma](https://github.com/joelpx/plasma) - Interactive disassembler for x86/ARM/MIPS. Generates indented pseudo-code with colored syntax code
 * [peda](https://github.com/longld/peda) - Python Exploit Development Assistance for GDB
 * [dnSpy](https://github.com/0xd4d/dnSpy) - dnSpy is a tool to reverse engineer .NET assemblies
+
+#### Physical Access Tools
+* [LAN Turtle](https://lanturtle.com/) - a covert "USB Ethernet Adapter" that provides remote access, network intelligence gathering, and MITM capabilities when installed in a local network.
+* [USB Rubber Ducky](http://usbrubberducky.com/) - customizable keystroke injection attack platform masquerading as a USB thumbdrive
+* [Poisontap](https://samy.pl/poisontap/) - siphons cookies, exposes internal (LAN-side) router and installs web backdoor on locked computers
 
 #### CTF Tools
 * [Pwntools](https://github.com/Gallopsled/pwntools) - Rapid exploit development framework built for use in CTFs


### PR DESCRIPTION
One category I've noticed is conspicuously missing from this list is the set of tools requiring physical access. These include the LAN Turtle, USB Rubber Ducky, and Poisontap. I'm sure there are more but these are the big three that I know about and would like to see added first.