### PR TITLE
Make grammar consistent: "command-line" -> "command line" and so on.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [Penetration testing](https://en.wikipedia.org/wiki/Penetration_test) is the practice of launching authorized, simulated attacks against computer systems and their physical infrastructure to expose potential security weaknesses and vulnerabilities.
 
-Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Please check the [Contributing Guidelines](CONTRIBUTING.md) for more details. This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/)
+Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Please check the [Contributing Guidelines](CONTRIBUTING.md) for more details. This work is licensed under a [Creative Commons Attribution 4.0 International License](http://creativecommons.org/licenses/by/4.0/).
 
 ## Contents
 
@@ -51,8 +51,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 - [Information Security Conferences](#information-security-conferences)
 - [Information Security Magazines](#information-security-magazines)
 - [Awesome Lists](#awesome-lists)
-- [Contribution](#contribution)
-- [License](#license)
 
 
 ## Online Resources
@@ -153,18 +151,18 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [sobelow](https://github.com/techgaun/sobelow) - Security-focused static analysis for the Phoenix Framework.
 
 #### Network Tools
-* [zmap](https://zmap.io/) - Open-source network scanner that enables researchers to easily perform Internet-wide network studies
-* [nmap](https://nmap.org/) - Free Security Scanner For Network Exploration & Security Audits
-* [pig](https://github.com/rafael-santiago/pig) - A Linux packet crafting tool
-* [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP
-* [tcpdump/libpcap](http://www.tcpdump.org/) - A common packet analyzer that runs under the command line
-* [Wireshark](https://www.wireshark.org/) - A network protocol analyzer for Unix and Windows
-* [Network Tools](http://network-tools.com/) - Different network tools: ping, lookup, whois, etc
-* [netsniff-ng](https://github.com/netsniff-ng/netsniff-ng) - A Swiss army knife for for network sniffing
-* [Intercepter-NG](http://sniff.su/) - a multifunctional network toolkit
-* [SPARTA](http://sparta.secforce.com/) - Network Infrastructure Penetration Testing Tool
-* [dnschef](https://github.com/iphelix/dnschef) - A highly configurable DNS proxy for pentesters
-* [DNSDumpster](https://dnsdumpster.com/) - Online DNS recon and search service
+* [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.
+* [nmap](https://nmap.org/) - Free security scanner for network exploration & security audits.
+* [pig](https://github.com/rafael-santiago/pig) - Linux packet crafting tool.
+* [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP.
+* [tcpdump/libpcap](http://www.tcpdump.org/) - Common packet analyzer that runs under the command line.
+* [Wireshark](https://www.wireshark.org/) - Network protocol analyzer for Unix and Windows.
+* [Network Tools](http://network-tools.com/) - Different network tools: ping, lookup, whois, etc.
+* [netsniff-ng](https://github.com/netsniff-ng/netsniff-ng) - A Swiss army knife for for network sniffing.
+* [Intercepter-NG](http://sniff.su/) - Multifunctional network toolkit.
+* [SPARTA](http://sparta.secforce.com/) - Network infrastructure penetration testing tool.
+* [dnschef](https://github.com/iphelix/dnschef) - Highly configurable DNS proxy for pentesters.
+* [DNSDumpster](https://dnsdumpster.com/) - Online DNS recon and search service.
 * [CloudFail](https://github.com/m0rtem/CloudFail) - Unmask server IP addresses hidden behind Cloudflare by searching old database records and detecting misconfigured DNS.
 * [dnsenum](https://github.com/fwaeytens/dnsenum/) - Perl script that enumerates DNS information from a domain, attempts zone transfers, performs a brute force dictionary style attack, and then performs reverse look-ups on the results.
 * [dnsmap](https://github.com/makefu/dnsmap/) - Passive DNS network mapper.
@@ -468,7 +466,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Pentest Cheat Sheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets) - Awesome Pentest Cheat Sheets.
 * [C/C++ Programming](https://github.com/fffaraz/awesome-cpp) - One of the main language for open source security tools.
 * [.NET Programming](https://github.com/quozd/awesome-dotnet) - Software framework for Microsoft Windows platform development.
-* [Shell Scripting](https://github.com/alebcay/awesome-shell) - Command-line frameworks, toolkits, guides and gizmos.
+* [Shell Scripting](https://github.com/alebcay/awesome-shell) - Command line frameworks, toolkits, guides and gizmos.
 * [Ruby Programming by @dreikanter](https://github.com/dreikanter/ruby-bookmarks) - The de-facto language for writing exploits.
 * [Ruby Programming by @markets](https://github.com/markets/awesome-ruby) - The de-facto language for writing exploits.
 * [Ruby Programming by @Sdogruyol](https://github.com/Sdogruyol/awesome-ruby) - The de-facto language for writing exploits.


### PR DESCRIPTION
This commit tidies some minor issues with pull request #141, namely:

* fix style guide compliance from accidental reversion during merge.
* add a period to the last sentence of the introduction paragraph.
* make the table of contents's content match the headings in the doc.
* consistently spell open source without a dashed word ("open-source").