### PR TITLE
Style guide compliance pass focused on Vulnerability Databases section.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,4 @@ rvm:
 before_script:
   - gem install awesome_bot
 script:
-  - awesome_bot README.md --allow-redirect
+  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion"

--- a/README.md
+++ b/README.md
@@ -396,21 +396,22 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 
 ## Vulnerability Databases
 * [Common Vulnerabilities and Exposures (CVE)](https://cve.mitre.org/) - Dictionary of common names (i.e., CVE Identifiers) for publicly known cybersecurity vulnerabilities.
-* [NVD](https://nvd.nist.gov/) - US National Vulnerability Database.
-* [CERT](https://www.us-cert.gov/) - US Computer Emergency Readiness Team.
-* [OSVDB](https://blog.osvdb.org/) - Open Sourced Vulnerability Database.
-* [Bugtraq](http://www.securityfocus.com/) - Symantec SecurityFocus.
-* [Exploit-DB](https://www.exploit-db.com/) - Offensive Security Exploit Database.
-* [Fulldisclosure](http://seclists.org/fulldisclosure/) - Full Disclosure Mailing List.
-* [MS Bulletin](https://technet.microsoft.com/en-us/security/bulletins) - Microsoft Security Bulletin.
-* [MS Advisory](https://technet.microsoft.com/en-us/security/advisories) - Microsoft Security Advisories.
-* [Inj3ct0r](http://www.1337day.com/) - Inj3ct0r Exploit Database.
-* [Packet Storm](https://packetstormsecurity.com/) - Packet Storm Global Security Resource.
-* [SecuriTeam](http://www.securiteam.com/) - Securiteam Vulnerability Information.
-* [CXSecurity](http://cxsecurity.com/) - CSSecurity Bugtraq List.
-* [Vulnerability Laboratory](http://www.vulnerability-lab.com/) - Vulnerability Research Laboratory.
-* [ZDI](http://www.zerodayinitiative.com/) - Zero Day Initiative.
+* [National Vulnerability Database (NVD)](https://nvd.nist.gov/) - United States government's National Vulnerability Database provides a superset of the standard CVE List along with a fine-grained search engine.
+* [US-CERT Vulnerability Notes Database](https://www.kb.cert.org/vuls/) - Summaries, technical details, remediation information, and lists of vendors affected by software vulnerabilities, aggregated by the United States Computer Emergency Response Team (US-CERT).
+* [Full-Disclosure](http://seclists.org/fulldisclosure/) - Public, vendor-neutral forum for detailed discussion of vulnerabilities, often publishes details before many other sources.
+* [Bugtraq (BID)](http://www.securityfocus.com/bid/) - Software security bug identification database compiled from submissions to the SecurityFocus mailing list, operated by Symantec, Inc.
+* [Exploit-DB](https://www.exploit-db.com/) - Non-profit project hosting exploits for software vulnerabilities, provided as a public service by Offensive Security.
+* [Microsoft Security Bulletins](https://technet.microsoft.com/en-us/security/bulletins#sec_search) - Announcements of security issues discovered in Microsoft software, published by the Microsoft Security Response Center (MSRC).
+* [Microsoft Security Advisories](https://technet.microsoft.com/en-us/security/advisories#APUMA) - Archive of security advisories impacting Microsoft software.
+* [Mozilla Foundation Security Advisories](https://www.mozilla.org/security/advisories/) - Archive of security advisories impacting Mozilla software, including the Firefox Web Browser.
+* [Packet Storm](https://packetstormsecurity.com/files/) - Compendium of exploits, advisories, tools, and other security-related resources aggregated from across the industry.
+* [CXSecurity](https://cxsecurity.com/) - Archive of published CVE and Bugtraq software vulnerabilities cross-referenced with a a Google dork database for discovering the listed vulnerability.
+* [SecuriTeam](http://www.securiteam.com/) - Independent source of software vulnerability information.
+* [Vulnerability Lab](https://www.vulnerability-lab.com/) - Open forum for security advisories organized by category of exploit target.
+* [Zero Day Initiative](http://zerodayinitiative.com/advisories/published/) - Bug bounty program with publicly accessible archive of published security advisories, operated by TippingPoint.
 * [Vulners](https://vulners.com) - Security database of software vulnerabilities.
+* [Inj3ct0r](http://www.0day.today) ([Onion service](http://mvfjfugdwgc5uwho.onion/)) - Exploit marketplace and vulnerability information aggregator.
+* [Open Source Vulnerability Database (OSVDB)](https://osvdb.org/) - Historical archive of security vulnerabilities in computerized equipment, no longer adding to its vulnerability database as of April, 2016.
 
 ## Security Courses
 * [Offensive Security Training](https://www.offensive-security.com/information-security-training/) - Training from BackTrack/Kali developers.

--- a/README.md
+++ b/README.md
@@ -395,6 +395,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Defcon Suggested Reading](https://www.defcon.org/html/links/book-list.html)
 
 ## Vulnerability Databases
+* [Common Vulnerabilities and Exposures (CVE)](https://cve.mitre.org/) - Dictionary of common names (i.e., CVE Identifiers) for publicly known cybersecurity vulnerabilities.
 * [NVD](https://nvd.nist.gov/) - US National Vulnerability Database.
 * [CERT](https://www.us-cert.gov/) - US Computer Emergency Readiness Team.
 * [OSVDB](https://blog.osvdb.org/) - Open Sourced Vulnerability Database.

--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Vulnerability Lab](https://www.vulnerability-lab.com/) - Open forum for security advisories organized by category of exploit target.
 * [Zero Day Initiative](http://zerodayinitiative.com/advisories/published/) - Bug bounty program with publicly accessible archive of published security advisories, operated by TippingPoint.
 * [Vulners](https://vulners.com) - Security database of software vulnerabilities.
-* [Inj3ct0r](http://www.0day.today) ([Onion service](http://mvfjfugdwgc5uwho.onion/)) - Exploit marketplace and vulnerability information aggregator.
+* [Inj3ct0r](https://www.0day.today) ([Onion service](http://mvfjfugdwgc5uwho.onion/)) - Exploit marketplace and vulnerability information aggregator.
 * [Open Source Vulnerability Database (OSVDB)](https://osvdb.org/) - Historical archive of security vulnerabilities in computerized equipment, no longer adding to its vulnerability database as of April, 2016.
 
 ## Security Courses


### PR DESCRIPTION
This pull request addresses the Awesome List style guide compliance issues against the Vulnerability Databases section. As before, descriptions have been added and acronyms in item links have been expanded. Additionally:

* Mozilla Foundation Security Advisories has been added to the list, since Firefox is a massive target.
* Microsoft Security Response Center links have been modified to link directly at their search forms.
* Mitre's CVE listing has been added.
* Fixed the link to the Inj3ct0r exploit marketplace and added its Onion service `.onion` domain, as well.
* Re-ordered the list with the most widely known items at the top. (This is somewhat arbitrary but I think my ordering will not be too controversial.)
* Note that OSVDB is historical-only, now; it no longer accepts new submissions as of April, 2016.

As an aside, I think Zero Day Initiative by TippingPoint is not really appropriate for this section because it is a bug bounty program. A new section for bug bounty programs may be more appropriate, or perhaps changing the headline from "Vulnerability Databases" to "Vulnerability Databases and Bug Bounty Programs" may make more sense, since bounty programs often create vulnerability databases as a natural byproduct of their operation.