### PR TITLE
Reorganize Vulnerability Scanners section, add subheadings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   - [Basic Penetration Testing Tools](#basic-penetration-testing-tools)
   - [Docker for Penetration Testing](#docker-for-penetration-testing)
   - [Vulnerability Scanners](#vulnerability-scanners)
+    - [Static Analyzers](#static-analyzers)
+    - [Web Scanners](#web-scanners)
   - [Network Tools](#network-tools)
   - [Wireless Network Tools](#wireless-network-tools)
   - [SSL Analysis Tools](#ssl-analysis-tools)
@@ -135,19 +137,27 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * `docker pull remnux/metasploit` - [docker-metasploit](https://hub.docker.com/r/remnux/metasploit/)
 
 ### Vulnerability Scanners
-* [Nexpose](https://www.rapid7.com/products/nexpose/) - Vulnerability management & risk management software.
-* [Nessus](http://www.tenable.com/products/nessus-vulnerability-scanner) - Vulnerability, configuration, and compliance assessment.
-* [Nikto](https://cirt.net/nikto2) - Web application vulnerability scanner.
-* [OpenVAS](http://www.openvas.org/) - Open Source vulnerability scanner and manager.
-* [Secapps](https://secapps.com/) - Integrated web application security testing environment.
-* [w3af](https://github.com/andresriancho/w3af) - Web application attack and audit framework.
-* [Wapiti](http://wapiti.sourceforge.net/) - Web application vulnerability scanner.
-* [WebReaver](http://www.webreaver.com/) - Web application vulnerability scanner for macOS.
-* [DVCS Ripper](https://github.com/kost/dvcs-ripper) - Rip web accessible (distributed) version control systems: SVN/GIT/HG/BZR.
-* [arachni](https://github.com/Arachni/arachni) - Web Application Security Scanner Framework.
+* [Nexpose](https://www.rapid7.com/products/nexpose/) - Commercial vulnerability and risk management assessment engine that integrates with Metasploit, sold by Rapid7.
+* [Nessus](https://www.tenable.com/products/nessus-vulnerability-scanner) - Commercial vulnerability management, configuration, and compliance assessment platform, sold by Tenable.
+* [OpenVAS](http://www.openvas.org/) - Free software implementation of the popular Nessus vulnerability assessment system.
 * [Vuls](https://github.com/future-architect/vuls) - Agentless vulnerability scanner for GNU/Linux and FreeBSD, written in Go.
+
+#### Static Analyzers
 * [Brakeman](https://github.com/presidentbeef/brakeman) - Static analysis security vulnerability scanner for Ruby on Rails applications.
+* [cppcheck](http://cppcheck.sourceforge.net/) - Extensible C/C++ static analyzer focused on finding bugs.
+* [FindBugs](http://findbugs.sourceforge.net/) - Free software static analyzer to look for bugs in Java code.
 * [sobelow](https://github.com/techgaun/sobelow) - Security-focused static analysis for the Phoenix Framework.
+
+#### Web Scanners
+* [Nikto](https://cirt.net/nikto2) - Noisy but fast black box web server and web application vulnerability scanner.
+* [Arachni](http://www.arachni-scanner.com/) - Scriptable framework for evaluating the security of web applications.
+* [w3af](https://github.com/andresriancho/w3af) - Web application attack and audit framework.
+* [Wapiti](http://wapiti.sourceforge.net/) - Black box web application vulnerability scanner with built-in fuzzer.
+* [SecApps](https://secapps.com/) - In-browser web application security testing suite.
+* [WebReaver](https://www.webreaver.com/) - Commercial, graphical web application vulnerability scanner designed for macOS.
+* [WPScan](https://wpscan.org/) - Black box WordPress vulnerability scanner.
+* [cms-explorer](https://code.google.com/archive/p/cms-explorer/) - Reveal the specific modules, plugins, components and themes that various websites powered by content management systems are running.
+* [joomscan](https://www.owasp.org/index.php/Category:OWASP_Joomla_Vulnerability_Scanner_Project) - Joomla vulnerability scanner.
 
 #### Network Tools
 * [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.
@@ -204,23 +214,21 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [OWASP Zed Attack Proxy](https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project) - Penetration testing tool for web applications.
 * [Burp Suite](https://portswigger.net/burp/) - Integrated platform for performing security testing of web applications.
 * [autochrome](https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2017/march/autochrome/) - Easy to install a test browser with all the appropriate setting needed for web application testing with native Burp support, from NCCGroup.
-* [WPScan](https://wpscan.org/) - Black box WordPress vulnerability scanner.
 * [Wordpress Exploit Framework](https://github.com/rastating/wordpress-exploit-framework) - Ruby framework for developing and using modules which aid in the penetration testing of WordPress powered websites and systems.
 * [WPSploit](https://github.com/espreto/wpsploit) - Exploit WordPress-powered websites with Metasploit.
 * [SQLmap](http://sqlmap.org/) - Automatic SQL injection and database takeover tool.
 * [tplmap](https://github.com/epinna/tplmap) - Automatic server-side template injection and Web server takeover tool.
 * [weevely3](https://github.com/epinna/weevely3) - Weaponized web shell.
 * [Wappalyzer](https://wappalyzer.com/) - Wappalyzer uncovers the technologies used on websites.
-* [cms-explorer](https://code.google.com/archive/p/cms-explorer/) - Reveal the specific modules, plugins, components and themes that various websites powered by content management systems are running.
-* [joomscan](https://www.owasp.org/index.php/Category:OWASP_Joomla_Vulnerability_Scanner_Project) - Joomla vulnerability scanner.
 * [WhatWeb](https://github.com/urbanadventurer/WhatWeb) - Website fingerprinter.
 * [BlindElephant](http://blindelephant.sourceforge.net/) - Web application fingerprinter.
 * [fimap](https://github.com/kurobeats/fimap) - Find, prepare, audit, exploit and even Google automatically for LFI/RFI bugs.
 * [Kadabra](https://github.com/D35m0nd142/Kadabra) - Automatic LFI exploiter and scanner.
 * [Kadimus](https://github.com/P0cL4bs/Kadimus) - LFI scan and exploit tool.
 * [liffy](https://github.com/hvqzao/liffy) - LFI exploitation tool.
-* [GitTools](https://github.com/internetwache/GitTools) - Automatically find and download Web-accessible `.git` repositories.
 * [Commix](https://github.com/commixproject/commix) - Automated all-in-one operating system command injection and exploitation tool.
+* [DVCS Ripper](https://github.com/kost/dvcs-ripper) - Rip web accessible (distributed) version control systems: SVN/GIT/HG/BZR.
+* [GitTools](https://github.com/internetwache/GitTools) - Automatically find and download Web-accessible `.git` repositories.
 
 ### Hex Editors
 * [HexEdit.js](https://hexed.it) - Browser-based hex editing.


### PR DESCRIPTION
This commit provides more detail and context for the vulnerability
scanners section. It groups Web Scanners into its own subheading, and
moves scanning tools from the Web Exploitation section into this section
as these tools do not actually focus on *exploiting* websites.

Additionally, Static Analyzers are grouped, two new static analyzers
(cppcheck and FindBugs) have been added, and commercial tools are
appropriately described as such.