### PR TITLE
Drop link to commercial-only VulnDB based off OSVDB.

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,7 +421,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Zero Day Initiative](http://zerodayinitiative.com/advisories/published/) - Bug bounty program with publicly accessible archive of published security advisories, operated by TippingPoint.
 * [Vulners](https://vulners.com/) - Security database of software vulnerabilities.
 * [Inj3ct0r](https://www.0day.today/) ([Onion service](http://mvfjfugdwgc5uwho.onion/)) - Exploit marketplace and vulnerability information aggregator.
-* [Open Source Vulnerability Database (OSVDB)](https://osvdb.org/) - Historical archive of security vulnerabilities in computerized equipment, no longer adding to its vulnerability database as of April, 2016. Continued by [Risk Based Security](https://vulndb.cyberriskanalytics.com/) as a commercial VDB.
+* [Open Source Vulnerability Database (OSVDB)](https://osvdb.org/) - Historical archive of security vulnerabilities in computerized equipment, no longer adding to its vulnerability database as of April, 2016.
 
 ## Security Courses
 * [Offensive Security Training](https://www.offensive-security.com/information-security-training/) - Training from BackTrack/Kali developers.


### PR DESCRIPTION
See [discussion](https://github.com/enaqx/awesome-pentest/pull/148#discussion_r126525306) for details and rationale.