### PR TITLE
Recategorize "Basic" tools section for clarity and conformity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   - [Operating Systems](#operating-systems)
 - [Tools](#tools)
   - [Penetration Testing Distributions](#penetration-testing-distributions)
-  - [Basic Penetration Testing Tools](#basic-penetration-testing-tools)
   - [Docker for Penetration Testing](#docker-for-penetration-testing)
+  - [Multi-paradigm Frameworks](#multi-paradigm-frameworks)
   - [Vulnerability Scanners](#vulnerability-scanners)
     - [Static Analyzers](#static-analyzers)
     - [Web Scanners](#web-scanners)
@@ -30,6 +30,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   - [Hash Cracking Tools](#hash-cracking-tools)
   - [Windows Utilities](#windows-utilities)
   - [GNU/Linux Utilities](#gnu-linux-utilities)
+  - [macOS Utilities](#macos-utilities)
   - [DDoS Tools](#ddos-tools)
   - [Social Engineering Tools](#social-engineering-tools)
   - [OSINT Tools](#osint-tools)
@@ -107,17 +108,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Fedora Security Lab](https://labs.fedoraproject.org/en/security/) - Provides a safe test environment to work on security auditing, forensics, system rescue and teaching security testing methodologies.
 * [The Pentesters Framework](https://github.com/trustedsec/ptf) - Distro organized around the Penetration Testing Execution Standard (PTES), providing a curated collection of utilities that eliminates often unused toolchains.
 
-### Basic Penetration Testing Tools
-* [Metasploit Framework](https://www.metasploit.com/) - World's most used penetration testing software.
-* [ExploitPack](https://github.com/juansacco/exploitpack) - Graphical tool for penetration testing with a bunch of exploits.
-* [BeEF](https://github.com/beefproject/beef) - Command and control server for delivering exploits to commandeered Web browsers.
-* [faraday](https://github.com/infobyte/faraday) - Collaborative penetration test and vulnerability management platform.
-* [evilgrade](https://github.com/infobyte/evilgrade) - The update explotation framework.
-* [routersploit](https://github.com/reverse-shell/routersploit) - Automated penetration testing software for router.
-* [redsnarf](https://github.com/nccgroup/redsnarf) - Post-exploitation tool for grabbing credentials.
-* [Bella](https://github.com/Trietptm-on-Security/Bella) - Pure Python post-exploitation data mining & remote administration tool for Mac OS.
-* [Offensive Web Testing Framework (OWTF)](https://www.owasp.org/index.php/OWASP_OWTF) - Python-based framework for pentesting Web applications based on the OWASP Testing Guide.
-
 ### Docker for Penetration Testing
 * `docker pull kalilinux/kali-linux-docker` [official Kali Linux](https://hub.docker.com/r/kalilinux/kali-linux-docker/)
 * `docker pull owasp/zap2docker-stable` - [official OWASP ZAP](https://github.com/zaproxy/zaproxy)
@@ -135,6 +125,12 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * `docker pull bkimminich/juice-shop` - [OWASP Juice Shop](https://github.com/bkimminich/juice-shop#docker-container--)
 * `docker pull kalilinux/kali-linux-docker` - [Kali Linux Docker Image](https://www.kali.org/news/official-kali-linux-docker-images/)
 * `docker pull remnux/metasploit` - [docker-metasploit](https://hub.docker.com/r/remnux/metasploit/)
+
+### Multi-paradigm Frameworks
+* [Metasploit](https://www.metasploit.com/) - Software for offensive security teams to help verify vulnerabilities and manage security assessments.
+* [Armitage](http://fastandeasyhacking.com/) - Java-based GUI front-end for the Metasploit Framework.
+* [Faraday](https://github.com/infobyte/faraday) - Multiuser integrated pentesting environment for red teams performing cooperative penetration tests, security audits, and risk assessments.
+* [ExploitPack](https://github.com/juansacco/exploitpack) - Graphical tool for automating penetration tests that ships with many pre-packaged exploits.
 
 ### Vulnerability Scanners
 * [Nexpose](https://www.rapid7.com/products/nexpose/) - Commercial vulnerability and risk management assessment engine that integrates with Metasploit, sold by Rapid7.
@@ -166,7 +162,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP.
 * [tcpdump/libpcap](http://www.tcpdump.org/) - Common packet analyzer that runs under the command line.
 * [Wireshark](https://www.wireshark.org/) - Network protocol analyzer for Unix and Windows.
-* [Network Tools](http://network-tools.com/) - Different network tools: ping, lookup, whois, etc.
+* [Network-Tools.com](http://network-tools.com/) - Website offering an interface to numerous basic network utilities like `ping`, `traceroute`, `whois`, and more.
 * [netsniff-ng](https://github.com/netsniff-ng/netsniff-ng) - Swiss army knife for for network sniffing.
 * [Intercepter-NG](http://sniff.su/) - Multifunctional network toolkit.
 * [SPARTA](http://sparta.secforce.com/) - Network infrastructure penetration testing tool.
@@ -193,10 +189,12 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [smbmap](https://github.com/ShawnDEvans/smbmap) - Handy SMB enumeration tool.
 * [scapy](https://github.com/secdev/scapy) - Python-based interactive packet manipulation program & library.
 * [Dshell](https://github.com/USArmyResearchLab/Dshell) - Network forensic analysis framework.
-* [Debookee (macOS)](http://www.iwaxx.com/debookee/) - Intercept traffic from any device on your network.
+* [Debookee](http://www.iwaxx.com/debookee/) - Simple and powerful network traffic analyzer for macOS.
 * [Dripcap](https://github.com/dripcap/dripcap) - Caffeinated packet analyzer.
 * [PRET](https://github.com/RUB-NDS/PRET) - Printer Exploitation Toolkit offers commands useful for printer attacks and fuzzing.
 * [Praeda](http://h.foofus.net/?page_id=218) - Automated multi-function printer data harvester for gathering usable data during security assessments.
+* [routersploit](https://github.com/reverse-shell/routersploit) - Open source exploitation framework similar to Metasploit but dedicated to embedded devices.
+* [evilgrade](https://github.com/infobyte/evilgrade) - Modular framework to take advantage of poor upgrade implementations by injecting fake updates.
 
 ### Wireless Network Tools
 * [Aircrack-ng](http://www.aircrack-ng.org/) - Set of tools for auditing wireless networks.
@@ -215,6 +213,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Fiddler](https://www.telerik.com/fiddler) - Free cross-platform web debugging proxy with user-friendly companion tools.
 * [Burp Suite](https://portswigger.net/burp/) - Integrated platform for performing security testing of web applications.
 * [autochrome](https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2017/march/autochrome/) - Easy to install a test browser with all the appropriate setting needed for web application testing with native Burp support, from NCCGroup.
+* [Browser Exploitation Framework (BeEF)](https://github.com/beefproject/beef) - Command and control server for delivering exploits to commandeered Web browsers.
+* [Offensive Web Testing Framework (OWTF)](https://www.owasp.org/index.php/OWASP_OWTF) - Python-based framework for pentesting Web applications based on the OWASP Testing Guide.
 * [Wordpress Exploit Framework](https://github.com/rastating/wordpress-exploit-framework) - Ruby framework for developing and using modules which aid in the penetration testing of WordPress powered websites and systems.
 * [WPSploit](https://github.com/espreto/wpsploit) - Exploit WordPress-powered websites with Metasploit.
 * [SQLmap](http://sqlmap.org/) - Automatic SQL injection and database takeover tool.
@@ -258,9 +258,13 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Empire](https://www.powershellempire.com/) - Pure PowerShell post-exploitation agent.
 * [Fibratus](https://github.com/rabbitstack/fibratus) - Tool for exploration and tracing of the Windows kernel.
 * [wePWNise](https://labs.mwrinfosecurity.com/tools/wepwnise/) - Generates architecture independent VBA code to be used in Office documents or templates and automates bypassing application control and exploit mitigation software.
+* [redsnarf](https://github.com/nccgroup/redsnarf) - Post-exploitation tool for retrieving password hashes and credentials from Windows workstations, servers, and domain controllers.
 
 ### GNU/Linux Utilities
 * [Linux Exploit Suggester](https://github.com/PenturaLabs/Linux_Exploit_Suggester) - Heuristic reporting on potentially viable exploits for a given GNU/Linux system.
+
+### macOS Utilities
+* [Bella](https://github.com/Trietptm-on-Security/Bella) - Pure Python post-exploitation data mining and remote administration tool for macOS.
 
 ### DDoS Tools
 * [LOIC](https://github.com/NewEraCracker/LOIC/) - Open source network stress tool for Windows.


### PR DESCRIPTION
This commit removes the "Basic Penetration Testing Tools" section and
moves numerous items listed therein into more appropriate places, based
on existing categories. For instance, BeEF is moved to the Web
Exploitation section, since it is more accurate to describe it as a Web
exploitation tool than a "Basic" tool. The former category is
descriptive while the latter is clearly nondescript.

A new section, "Multi-paradigm Frameworks," has been added for items
that were listed under the removed "Basic" section but that do not
cleanly fit into an existing category. Namely, these are Metasploit,
ExploitPack, and Faraday, which are exceptions simply because they are
so versatile. (Hence the choice of the new section, "Multi-paradigm.")

Additionally, the well-known Armitage GUI for Metasploit was added.

Moreover, Bella was moved to a new section, "macOS Utilities," which
provides parity with the existing Windows Utilities and GNU/Linux
Utilities section. Bella is a post-exploitation agent similar to
redsnarf, which likewise has been moved out of the "Basic" section and
into its more appropriate Windows Utilities section.

Other minor touch ups to various item descriptions were also made.