### PR TITLE
Move `sslstrip` to Web Exploitation, recategorize SSL as TLS tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
     - [Web Scanners](#web-scanners)
   - [Network Tools](#network-tools)
   - [Wireless Network Tools](#wireless-network-tools)
-  - [SSL Analysis Tools](#ssl-analysis-tools)
+  - [Transport Layer Security Tools](#transport-layer-security-tools)
   - [Web Exploitation](#web-exploitation)
   - [Hex Editors](#hex-editors)
   - [Hash Cracking Tools](#hash-cracking-tools)
@@ -177,7 +177,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [passivedns](https://github.com/gamelinux/passivedns) - Network sniffer that logs all DNS server replies for use in a passive DNS setup.
 * [Mass Scan](https://github.com/robertdavidgraham/masscan) - TCP port scanner, spews SYN packets asynchronously, scanning entire Internet in under 5 minutes.
 * [Zarp](https://github.com/hatRiot/zarp) - Network attack tool centered around the exploitation of local networks.
-* [mitmproxy](https://github.com/mitmproxy/mitmproxy) - Interactive SSL-capable intercepting HTTP proxy for penetration testers and software developers.
+* [mitmproxy](https://github.com/mitmproxy/mitmproxy) - Interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers.
 * [Morpheus](https://github.com/r00t-3xp10it/morpheus) - Automated ettercap TCP/IP Hijacking tool.
 * [mallory](https://github.com/justmao945/mallory) - HTTP/HTTPS proxy over SSH.
 * [SSH MITM](https://github.com/jtesta/ssh-mitm) - Intercept SSH connections with a proxy; all plaintext passwords and sessions are logged to disk.
@@ -203,10 +203,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Reaver](https://code.google.com/archive/p/reaver-wps) - Brute force attack against WiFi Protected Setup.
 * [Wifite](https://github.com/derv82/wifite) - Automated wireless attack tool.
 
-### SSL Analysis Tools
-* [SSLyze](https://github.com/nabla-c0d3/sslyze) - SSL configuration scanner.
-* [sslstrip](https://www.thoughtcrime.org/software/sslstrip/) - Demonstration of the HTTPS stripping attacks.
-* [sslstrip2](https://github.com/LeonardoNve/sslstrip2) - SSLStrip version to defeat HSTS.
+### Transport Layer Security Tools
+* [SSLyze](https://github.com/nabla-c0d3/sslyze) - Fast and comprehensive TLS/SSL configuration analyzer to help identify security mis-configurations.
 * [tls_prober](https://github.com/WestpointLtd/tls_prober) - Fingerprint a server's SSL/TLS implementation.
 
 ### Web Exploitation
@@ -232,6 +230,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Commix](https://github.com/commixproject/commix) - Automated all-in-one operating system command injection and exploitation tool.
 * [DVCS Ripper](https://github.com/kost/dvcs-ripper) - Rip web accessible (distributed) version control systems: SVN/GIT/HG/BZR.
 * [GitTools](https://github.com/internetwache/GitTools) - Automatically find and download Web-accessible `.git` repositories.
+* [sslstrip](https://www.thoughtcrime.org/software/sslstrip/) - Demonstration of the HTTPS stripping attacks.
+* [sslstrip2](https://github.com/LeonardoNve/sslstrip2) - SSLStrip version to defeat HSTS.
 
 ### Hex Editors
 * [HexEdit.js](https://hexed.it) - Browser-based hex editing.


### PR DESCRIPTION
This commit updates numerous tools all previously categorized as "SSL"
tools. It updates their descriptions to more accurately describe current
versions by remarking on TLS capabilities, and it does the same with the
section heading. Further, Web-centric exploitation tools related to
SSL/TLS implementations have been moved to the Web Exploitation section,
where they arguably more properly belong, as SSL/TLS implementations may
include application-layer services beyond simply HTTP and "Web" traffic.