### PR TITLE
Add ChipWhisperer, a side-channel attack toolchain, in new section.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   - [Anonymity Tools](#anonymity-tools)
   - [Reverse Engineering Tools](#reverse-engineering-tools)
   - [Physical Access Tools](#physical-access-tools)
+  - [Side-channel Tools](#side-channel-tools)
   - [CTF Tools](#ctf-tools)
 - [Books](#books)
   - [Penetration Testing Books](#penetration-testing-books)
@@ -337,6 +338,9 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [USB Rubber Ducky](http://usbrubberducky.com/) - Customizable keystroke injection attack platform masquerading as a USB thumbdrive.
 * [Poisontap](https://samy.pl/poisontap/) - Siphons cookies, exposes internal (LAN-side) router and installs web backdoor on locked computers.
 * [WiFi Pineapple](https://www.wifipineapple.com/) - Wireless auditing and penetration testing platform.
+
+### Side-channel Tools
+* [ChipWhisperer](http://chipwhisperer.com) - Complete open-source toolchain for side-channel power analysis and glitching attacks.
 
 ### CTF Tools
 * [ctf-tools](https://github.com/zardus/ctf-tools) - Collection of setup scripts to install various security research tools easily and quickly deployable to new machines.


### PR DESCRIPTION
I noticed that completely missing from this list are side-channel attack vectors and tools to aid in their discovery and exploitation, so, I'm adding some that I know about. These may not be the most "awesome" tools in this category, simply the ones I'm aware of.