### PR TITLE
Expand acronyms, improve descriptions, add OSSTMM item.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,12 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 
 ### Penetration Testing Resources
 * [Metasploit Unleashed](https://www.offensive-security.com/metasploit-unleashed/) - Free Offensive Security Metasploit course.
-* [PTES](http://www.pentest-standard.org/) - Penetration Testing Execution Standard.
-* [OWASP](https://www.owasp.org/index.php/Main_Page) - Open Web Application Security Project.
-* [PENTEST-WIKI](https://github.com/nixawk/pentest-wiki) - Free online security knowledge library for pentesters / researchers.
-* [Vulnerability Assessment Framework](http://www.vulnerabilityassessment.co.uk/Penetration%20Test.html) - Penetration Testing Framework.
+* [Penetration Testing Execution Standard (PTES)](http://www.pentest-standard.org/) - Documentation designed to provide a common language and scope for performing and reporting the results of a penetration test.
+* [Open Web Application Security Project (OWASP)](https://www.owasp.org/index.php/Main_Page) - Worldwide not-for-profit charitable organization focused on improving the security of especially Web-based and Application-layer software.
+* [PENTEST-WIKI](https://github.com/nixawk/pentest-wiki) - Free online security knowledge library for pentesters and researchers.
+* [Penetration Testing Framework (PTF)](http://www.vulnerabilityassessment.co.uk/Penetration%20Test.html) - Outline for performing penetration tests compiled as a general framework usable by vulnerability analysts and penetration testers alike.
 * [XSS-Payloads](http://www.xss-payloads.com) - Ultimate resource for all things cross-site including payloads, tools, games and documentation.
+* [Open Source Security Testing Methodology Manual (OSSTMM)](http://www.isecom.org/mirror/OSSTMM.3.pdf) - Framework for providing test cases that result in verified facts on which to base decisions that impact an organization's security.
 
 ### Exploit Development
 * [Shellcode Tutorial](http://www.vividmachines.com/shellcode/shellcode.html) - Tutorial on how to write shellcode.


### PR DESCRIPTION
This commit focses on the Penetration Testing Resources section and
provides better descriptions for most of the items therein. It also adds
the OSSTMM version 3 pentest methodology manual, which seems fitting as
it is both listed by OWASP and fits nicely with the PTES and PTF items
already listed.