### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * `docker pull citizenstig/nowasp` - [OWASP Mutillidae II Web Pen-Test Practice Application](https://hub.docker.com/r/citizenstig/nowasp/)
 * `docker pull bkimminich/juice-shop` - [OWASP Juice Shop](https://github.com/bkimminich/juice-shop#docker-container--)
 * `docker pull kalilinux/kali-linux-docker` - [Kali Linux Docker Image](https://www.kali.org/news/official-kali-linux-docker-images/)
-* `docker pull remnux/metasploit` - [docker-metasploit](https://hub.docker.com/r/remnux/metasploit/)
+* `docker pull phocean/msf` - [docker-metasploit](https://hub.docker.com/r/phocean/msf/)
 
 ### Multi-paradigm Frameworks
 * [Metasploit](https://www.metasploit.com/) - Software for offensive security teams to help verify vulnerabilities and manage security assessments.


### PR DESCRIPTION
Switch the Metasploit Docker to the original repo on which REMnux, a generic distro, is based. It is more up-to-date, maintained.