### PR TITLE
Added ACSTIS to Web Scanners

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [WPScan](https://wpscan.org/) - Black box WordPress vulnerability scanner.
 * [cms-explorer](https://code.google.com/archive/p/cms-explorer/) - Reveal the specific modules, plugins, components and themes that various websites powered by content management systems are running.
 * [joomscan](https://www.owasp.org/index.php/Category:OWASP_Joomla_Vulnerability_Scanner_Project) - Joomla vulnerability scanner.
+* [ACSTIS](https://github.com/tijme/angularjs-csti-scanner) - Automated client-side template injection (sandbox escape/bypass) detection for AngularJS.
 
 ### Network Tools
 * [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.


### PR DESCRIPTION
[ACSTIS](https://github.com/tijme/angularjs-csti-scanner) helps you to scan certain web applications for AngularJS Client-Side Template Injection (sometimes referred to as CSTI, sandbox escape or sandbox bypass). It supports scanning a single request but also crawling the entire web application for the AngularJS CSTI vulnerability.