### PR TITLE
Remove Dead Link From List- "Hack3rcon"

### DIFF
--- a/README.md
+++ b/README.md
@@ -559,7 +559,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Hackfest](https://hackfest.ca) - Largest hacking conference in Canada.
 * [HITB](https://conference.hitb.org/) - Deep-knowledge security conference held in Malaysia and The Netherlands.
 * [Troopers](https://www.troopers.de) - Annual international IT Security event with workshops held in Heidelberg, Germany.
-* [Hack3rCon](http://hack3rcon.org/) - Annual US hacker conference.
 * [ThotCon](http://thotcon.org/) - Annual US hacker conference held in Chicago.
 * [LayerOne](http://www.layerone.org/) - Annual US security conference held every spring in Los Angeles.
 * [DeepSec](https://deepsec.net/) - Security Conference in Vienna, Austria.


### PR DESCRIPTION
Remove line 562 "* [Hack3rCon](http://hack3rcon.org/) - Annual US hacker conference." because the link leads to a domain squatting website rather than an actual hacker conference.