### PR TITLE
Sub-categorize "Network Tools" section, clarify "Defense," add Iodine.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,16 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
     * [Static Analyzers](#static-analyzers)
     * [Web Vulnerability Scanners](#web-vulnerability-scanners)
   * [Network Tools](#network-tools)
+    * [Exfiltration Tools](#exfiltration-tools)
+    * [Network Reconnaissance Tools](#network-reconnaissance-tools)
+    * [Protocol Analyzers and Sniffers](#protocol-analyzers-and-sniffers)
+    * [Proxies and MITM Tools](#proxies-and-mitm-tools)
   * [Wireless Network Tools](#wireless-network-tools)
   * [Transport Layer Security Tools](#transport-layer-security-tools)
   * [Web Exploitation](#web-exploitation)
   * [Hex Editors](#hex-editors)
   * [File Format Analysis Tools](#file-format-analysis-tools)
-  * [Defense Evasion Tools](#defense-evasion-tools)
+  * [Anti-virus Evasion Tools](#anti-virus-evasion-tools)
   * [Hash Cracking Tools](#hash-cracking-tools)
   * [Windows Utilities](#windows-utilities)
   * [GNU/Linux Utilities](#gnulinux-utilities)
@@ -183,17 +187,32 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 
 ### Network Tools
 
-* [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.
-* [nmap](https://nmap.org/) - Free security scanner for network exploration & security audits.
 * [pig](https://github.com/rafael-santiago/pig) - GNU/Linux packet crafting tool.
-* [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP.
-* [tcpdump/libpcap](http://www.tcpdump.org/) - Common packet analyzer that runs under the command line.
-* [Wireshark](https://www.wireshark.org/) - Widely-used graphical, cross-platform network protocol analyzer.
 * [Network-Tools.com](http://network-tools.com/) - Website offering an interface to numerous basic network utilities like `ping`, `traceroute`, `whois`, and more.
-* [netsniff-ng](https://github.com/netsniff-ng/netsniff-ng) - Swiss army knife for for network sniffing.
 * [Intercepter-NG](http://sniff.su/) - Multifunctional network toolkit.
 * [SPARTA](https://sparta.secforce.com/) - Graphical interface offering scriptable, configurable access to existing network infrastructure scanning and enumeration tools.
-* [dnschef](https://github.com/iphelix/dnschef) - Highly configurable DNS proxy for pentesters.
+* [Zarp](https://github.com/hatRiot/zarp) - Network attack tool centered around the exploitation of local networks.
+* [dsniff](https://www.monkey.org/~dugsong/dsniff/) - Collection of tools for network auditing and pentesting.
+* [scapy](https://github.com/secdev/scapy) - Python-based interactive packet manipulation program & library.
+* [Printer Exploitation Toolkit (PRET)](https://github.com/RUB-NDS/PRET) - Tool for printer security testing capable of IP and USB connectivity, fuzzing, and exploitation of PostScript, PJL, and PCL printer language features.
+* [Praeda](http://h.foofus.net/?page_id=218) - Automated multi-function printer data harvester for gathering usable data during security assessments.
+* [routersploit](https://github.com/reverse-shell/routersploit) - Open source exploitation framework similar to Metasploit but dedicated to embedded devices.
+* [CrackMapExec](https://github.com/byt3bl33d3r/CrackMapExec) - Swiss army knife for pentesting networks.
+* [impacket](https://github.com/CoreSecurity/impacket) - Collection of Python classes for working with network protocols.
+* [dnstwist](https://github.com/elceef/dnstwist) - Domain name permutation engine for detecting typo squatting, phishing and corporate espionage.
+
+#### Exfiltration Tools
+
+* [DET](https://github.com/sensepost/DET) - Proof of concept to perform data exfiltration using either single or multiple channel(s) at the same time.
+* [pwnat](https://github.com/samyk/pwnat) - Punches holes in firewalls and NATs.
+* [tgcd](http://tgcd.sourceforge.net/) - Simple Unix network utility to extend the accessibility of TCP/IP based network services beyond firewalls.
+* [Iodine](https://code.kryo.se/iodine/) - Tunnel IPv4 data through a DNS server; useful for exfiltration from networks where Internet access is firewalled, but DNS queries are allowed.
+
+#### Network Reconnaissance Tools
+
+* [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.
+* [nmap](https://nmap.org/) - Free security scanner for network exploration & security audits.
+* [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP.
 * [DNSDumpster](https://dnsdumpster.com/) - Online DNS recon and search service.
 * [CloudFail](https://github.com/m0rtem/CloudFail) - Unmask server IP addresses hidden behind Cloudflare by searching old database records and detecting misconfigured DNS.
 * [dnsenum](https://github.com/fwaeytens/dnsenum/) - Perl script that enumerates DNS information from a domain, attempts zone transfers, performs a brute force dictionary style attack, and then performs reverse look-ups on the results.
@@ -203,32 +222,30 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [passivedns-client](https://github.com/chrislee35/passivedns-client) - Library and query tool for querying several passive DNS providers.
 * [passivedns](https://github.com/gamelinux/passivedns) - Network sniffer that logs all DNS server replies for use in a passive DNS setup.
 * [Mass Scan](https://github.com/robertdavidgraham/masscan) - TCP port scanner, spews SYN packets asynchronously, scanning entire Internet in under 5 minutes.
-* [Zarp](https://github.com/hatRiot/zarp) - Network attack tool centered around the exploitation of local networks.
+* [smbmap](https://github.com/ShawnDEvans/smbmap) - Handy SMB enumeration tool.
+* [XRay](https://github.com/evilsocket/xray) - Network (sub)domain discovery and reconnaissance automation tool.
+* [ACLight](https://github.com/cyberark/ACLight) - Script for advanced discovery of sensitive Privileged Accounts - includes Shadow Admins.
+
+#### Protocol Analyzers and Sniffers
+
+* [tcpdump/libpcap](http://www.tcpdump.org/) - Common packet analyzer that runs under the command line.
+* [Wireshark](https://www.wireshark.org/) - Widely-used graphical, cross-platform network protocol analyzer.
+* [netsniff-ng](https://github.com/netsniff-ng/netsniff-ng) - Swiss army knife for for network sniffing.
+* [Dshell](https://github.com/USArmyResearchLab/Dshell) - Network forensic analysis framework.
+* [Debookee](http://www.iwaxx.com/debookee/) - Simple and powerful network traffic analyzer for macOS.
+* [Dripcap](https://github.com/dripcap/dripcap) - Caffeinated packet analyzer.
+* [Netzob](https://github.com/netzob/netzob) - Reverse engineering, traffic generation and fuzzing of communication protocols.
+
+#### Proxies and MITM Tools
+
+* [dnschef](https://github.com/iphelix/dnschef) - Highly configurable DNS proxy for pentesters.
 * [mitmproxy](https://github.com/mitmproxy/mitmproxy) - Interactive TLS-capable intercepting HTTP proxy for penetration testers and software developers.
 * [Morpheus](https://github.com/r00t-3xp10it/morpheus) - Automated ettercap TCP/IP Hijacking tool.
 * [mallory](https://github.com/justmao945/mallory) - HTTP/HTTPS proxy over SSH.
 * [SSH MITM](https://github.com/jtesta/ssh-mitm) - Intercept SSH connections with a proxy; all plaintext passwords and sessions are logged to disk.
-* [Netzob](https://github.com/netzob/netzob) - Reverse engineering, traffic generation and fuzzing of communication protocols.
-* [DET](https://github.com/sensepost/DET) - Proof of concept to perform data exfiltration using either single or multiple channel(s) at the same time.
-* [pwnat](https://github.com/samyk/pwnat) - Punches holes in firewalls and NATs.
-* [dsniff](https://www.monkey.org/~dugsong/dsniff/) - Collection of tools for network auditing and pentesting.
-* [tgcd](http://tgcd.sourceforge.net/) - Simple Unix network utility to extend the accessibility of TCP/IP based network services beyond firewalls.
-* [smbmap](https://github.com/ShawnDEvans/smbmap) - Handy SMB enumeration tool.
-* [scapy](https://github.com/secdev/scapy) - Python-based interactive packet manipulation program & library.
-* [Dshell](https://github.com/USArmyResearchLab/Dshell) - Network forensic analysis framework.
-* [Debookee](http://www.iwaxx.com/debookee/) - Simple and powerful network traffic analyzer for macOS.
-* [Dripcap](https://github.com/dripcap/dripcap) - Caffeinated packet analyzer.
-* [Printer Exploitation Toolkit (PRET)](https://github.com/RUB-NDS/PRET) - Tool for printer security testing capable of IP and USB connectivity, fuzzing, and exploitation of PostScript, PJL, and PCL printer language features.
-* [Praeda](http://h.foofus.net/?page_id=218) - Automated multi-function printer data harvester for gathering usable data during security assessments.
-* [routersploit](https://github.com/reverse-shell/routersploit) - Open source exploitation framework similar to Metasploit but dedicated to embedded devices.
 * [evilgrade](https://github.com/infobyte/evilgrade) - Modular framework to take advantage of poor upgrade implementations by injecting fake updates.
-* [XRay](https://github.com/evilsocket/xray) - Network (sub)domain discovery and reconnaissance automation tool.
 * [Ettercap](http://www.ettercap-project.org) - Comprehensive, mature suite for machine-in-the-middle attacks.
 * [BetterCAP](https://www.bettercap.org/) - Modular, portable and easily extensible MITM framework.
-* [CrackMapExec](https://github.com/byt3bl33d3r/CrackMapExec) - Swiss army knife for pentesting networks.
-* [impacket](https://github.com/CoreSecurity/impacket) - Collection of Python classes for working with network protocols.
-* [ACLight](https://github.com/cyberark/ACLight) - Script for advanced discovery of sensitive Privileged Accounts - includes Shadow Admins.
-* [dnstwist](https://github.com/elceef/dnstwist) - Domain name permutation engine for detecting typo squatting, phishing and corporate espionage.
 
 ### Wireless Network Tools
 
@@ -291,7 +308,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Veles](https://codisec.com/veles/) - Binary data visualization and analysis tool.
 * [Hachoir](http://hachoir3.readthedocs.io/) - Python library to view and edit a binary stream as tree of fields and tools for metadata extraction.
 
-### Defense Evasion Tools
+### Anti-virus Evasion Tools
 
 * [Veil](https://www.veil-framework.com/) - Generate metasploit payloads that bypass common anti-virus solutions.
 * [shellsploit](https://github.com/Exploit-install/shellsploit-framework) - Generates custom shellcode, backdoors, injectors, optionally obfuscates every byte via encoders.


### PR DESCRIPTION
Iodine is a DNS tunnel and useful for data exfiltration.

The Network Tools section became very long, so I chunked it up with
subcategories that pertain to the sort of tool. ("Network Tools" is
itself somewhat vague, and multi-paradigm/multi-function tools were
retained in the root of the category.)

Finally, "Defense Evasion Tools" was renamed to "Anti-virus Evasion
Tools" because every utility listed there was actually an AV or
host-based defense evasion tool, which is distinct from the network
evasion tools (exfiltration utilities) already listed in the "Network
Tools" section, above. I believe this clarity will help a reader more
quickly find the specific type of "defense evasion" utility they are
actually looking for.