### PR TITLE
Amass is now an official OWASP project. Add Python3 port of `fierce`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [XRay](https://github.com/evilsocket/xray) - Network (sub)domain discovery and reconnaissance automation tool.
 * [ACLight](https://github.com/cyberark/ACLight) - Script for advanced discovery of sensitive Privileged Accounts - includes Shadow Admins.
 * [ScanCannon](https://github.com/johnnyxmas/ScanCannon) - Python script to quickly enumerate large networks by calling `masscan` to quickly identify open ports and then `nmap` to gain details on the systems/services on those ports.
+* [fierce](https://github.com/mschwager/fierce) - Python3 port of the original `fierce.pl` DNS reconnaissance tool for locating non-contiguous IP space.
 
 #### Protocol Analyzers and Sniffers
 
@@ -420,7 +421,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Intrigue](http://intrigue.io) - Automated OSINT & Attack Surface discovery framework with powerful API, UI and CLI.
 * [ZoomEye](https://www.zoomeye.org/) - Search engine for cyberspace that lets the user find specific network components.
 * [gOSINT](https://github.com/Nhoya/gOSINT) - OSINT tool with multiple modules and a telegram scraper.
-* [Amass](https://github.com/caffix/amass) - Subdomain enumeration via scraping, web archives, brute forcing, permutations, reverse DNS sweeping, TLS certificates, passive DNS data sources, etc.
+* [OWASP Amass](https://github.com/OWASP/Amass) - Subdomain enumeration via scraping, web archives, brute forcing, permutations, reverse DNS sweeping, TLS certificates, passive DNS data sources, etc.
 * [Hunter.io](https://hunter.io/) - Data broker providing a Web search interface for discovering the email addresses and other organizational details of a company.
 * [FOCA (Fingerprinting Organizations with Collected Archives)](https://www.elevenpaths.com/labstools/foca/) - Automated document harvester that searches Google, Bing, and DuckDuckGo to find and extrapolate internal company organizational structures.
 


### PR DESCRIPTION
This PR contains two small changes related to DNS recon tools:

* The Amass subdomain enumeration tool's repository has moved to its new home in the OWASP organization. This PR updates the link to this tool in our list.
* One of the most famous DNS enumeration tools, `fierce.pl`, has been ported to Python3 but retains the same interface, and I think is awesome enough to be included here.