### PR TITLE
Add RegEx-DoS, an analyzer for regular expressions susceptible to DoS attacks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [sobelow](https://github.com/nccgroup/sobelow) - Security-focused static analysis for the Phoenix Framework.
 * [bandit](https://pypi.python.org/pypi/bandit/) - Security oriented static analyser for python code.
 * [Progpilot](https://github.com/designsecurity/progpilot) - Static security analysis tool for PHP code.
+* [RegEx-DoS](https://github.com/jagracey/RegEx-DoS) - Analyzes source code for Regular Expressions susceptible to Denial of Service attacks.
 
 #### Web Vulnerability Scanners
 


### PR DESCRIPTION
A [ReDoS attack](https://www.owasp.org/index.php/Regular_expression_Denial_of_Service_-_ReDoS) is a denial of service condition executed by exploiting the nature of certain regular expression engines that require exponential time to compute a given input. This tool is a static analyzer that searches through source code and reports risk levels for any regular expressions found.