### PR TITLE
Add CertGraph, crawl TLS certs for certificate alternative names.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Intel Techniques](https://inteltechniques.com/menu.html) - Collection of OSINT tools. Menu on the left can be used to navigate through the categories.
 * [NetBootcamp OSINT Tools](http://netbootcamp.org/osinttools/) - Collection of OSINT links and custom Web interfaces to other services such as [Facebook Graph Search](http://netbootcamp.org/facebook.html) and [various paste sites](http://netbootcamp.org/pastesearch.html).
 * [WiGLE.net](https://wigle.net/) - Information about wireless networks world-wide, with user-friendly desktop and web applications.
+* [CertGraph](https://github.com/lanrat/certgraph) - Crawls a domain's SSL/TLS certificates for its certificate alternative names.
 
 ### Social Engineering Resources
 


### PR DESCRIPTION
This tool can connect to a domain over HTTP or SMTP, or search Certificate
Transparency (CT) logs in order to create a directed graph that
visualizes a domain's certificate's certificate alternative names. These
are other domain names that the certificate can be used to authenticate,
even if those domain names are not in public DNS records. Can be used as
an OSINT investigative tool as a task in the reconnaisance phase of a
pentesting engagement in order to easily discover additional targets.