### PR TITLE
Fix Travis CI build errors, largely due to stale links.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,13 @@
+---
 language: ruby
-dist: trusty
+sudo: required
 rvm:
-  - 2.2
-before_script:
+  - 2.4.1
+
+install:
+  - sudo apt update --yes
+  - sudo apt install ca-certificates
   - gem install awesome_bot
-  - wget 'https://mkcert.org/generate/' -O bundle.pem
-  - wget 'http://cdp.pca.dfn.de/global-root-ca/pub/cacert/cacert.pem' -O dfn.pem
-  - wget 'http://cdp.pca.dfn.de/uni-potsdam-ca/pub/cacert/cacert.pem' -O potsdam.pem
-  - cat bundle.pem dfn.pem potsdam.pem > /tmp/bundle.pem
+
 script:
-  - SSL_CERT_FILE="/tmp/bundle.pem" awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,zoomeye.org,netsparker.com"
+  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,zoomeye.org,netsparker.com,www.shodan.io,www.mhprofessional.com"

--- a/README.md
+++ b/README.md
@@ -181,7 +181,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [SecApps](https://secapps.com/) - In-browser web application security testing suite.
 * [WebReaver](https://www.webreaver.com/) - Commercial, graphical web application vulnerability scanner designed for macOS.
 * [WPScan](https://wpscan.org/) - Black box WordPress vulnerability scanner.
-* [Zoom](https://github.com/UltimateHackers/Zoom) - Powerful wordpress username enumerator with infinite scanning.
 * [cms-explorer](https://code.google.com/archive/p/cms-explorer/) - Reveal the specific modules, plugins, components and themes that various websites powered by content management systems are running.
 * [joomscan](https://www.owasp.org/index.php/Category:OWASP_Joomla_Vulnerability_Scanner_Project) - Joomla vulnerability scanner.
 * [ACSTIS](https://github.com/tijme/angularjs-csti-scanner) - Automated client-side template injection (sandbox escape/bypass) detection for AngularJS.
@@ -300,7 +299,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [GitTools](https://github.com/internetwache/GitTools) - Automatically find and download Web-accessible `.git` repositories.
 * [sslstrip](https://www.thoughtcrime.org/software/sslstrip/) - Demonstration of the HTTPS stripping attacks.
 * [sslstrip2](https://github.com/LeonardoNve/sslstrip2) - SSLStrip version to defeat HSTS.
-* [NoSQLmap](http://nosqlmap.net/) - Automatic NoSQL injection and database takeover tool.
+* [NoSQLmap](https://github.com/codingo/NoSQLMap) - Automatic NoSQL injection and database takeover tool.
 * [VHostScan](https://github.com/codingo/VHostScan) - A virtual host scanner that performs reverse lookups, can be used with pivot tools, detect catch-all scenarios, aliases and dynamic default pages.
 * [FuzzDB](https://github.com/fuzzdb-project/fuzzdb) - Dictionary of attack patterns and primitives for black-box application fault injection and resource discovery.
 * [EyeWitness](https://github.com/ChrisTruncer/EyeWitness) - Tool to take screenshots of websites, provide some server header info, and identify default credentials if possible.
@@ -404,7 +403,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [creepy](https://github.com/ilektrojohn/creepy) - Geolocation OSINT tool.
 * [metagoofil](https://github.com/laramies/metagoofil) - Metadata harvester.
 * [Google Hacking Database](https://www.exploit-db.com/google-hacking-database/) - Database of Google dorks; can be used for recon.
-* [Google-dorks](https://github.com/JohnTroony/Google-dorks) - Common Google dorks and others you probably don't know.
 * [GooDork](https://github.com/k3170makan/GooDork) - Command line Google dorking tool.
 * [dork-cli](https://github.com/jgor/dork-cli) - Command line Google dork tool.
 * [Censys](https://www.censys.io/) - Collects data on hosts and websites through daily ZMap and ZGrab scans.
@@ -557,7 +555,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [No Tech Hacking by Johnny Long & Jack Wiles, 2008](https://www.elsevier.com/books/no-tech-hacking/mitnick/978-1-59749-215-7)
 * [Social Engineering: The Art of Human Hacking by Christopher Hadnagy, 2010](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470639539.html)
 * [Unmasking the Social Engineer: The Human Element of Security by Christopher Hadnagy, 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118608577.html)
-* [Social Engineering in IT Security: Tools, Tactics, and Techniques by Sharon Conheady, 2014](https://www.mhprofessional.com/product.php?isbn=0071818464)
+* [Social Engineering in IT Security: Tools, Tactics, and Techniques by Sharon Conheady, 2014](https://www.mhprofessional.com/9780071818469-usa-social-engineering-in-it-security-tools-tactics-and-techniques-group)
 
 ### Lock Picking Books
 
@@ -588,7 +586,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Zero Day Initiative](http://zerodayinitiative.com/advisories/published/) - Bug bounty program with publicly accessible archive of published security advisories, operated by TippingPoint.
 * [Vulners](https://vulners.com/) - Security database of software vulnerabilities.
 * [Inj3ct0r](https://www.0day.today/) ([Onion service](http://mvfjfugdwgc5uwho.onion/)) - Exploit marketplace and vulnerability information aggregator.
-* [Open Source Vulnerability Database (OSVDB)](https://osvdb.org/) - Historical archive of security vulnerabilities in computerized equipment, no longer adding to its vulnerability database as of April, 2016.
 * [HPI-VDB](https://hpi-vdb.de/) - Aggregator of cross-referenced software vulnerabilities offering free-of-charge API access, provided by the Hasso-Plattner Institute, Potsdam.
 * [China National Vulnerability Database (CNNVD)](http://www.cnnvd.org.cn/) - Chinese government-run vulnerability database analoguous to the United States's CVE database hosted by Mitre Corporation.
 
@@ -625,7 +622,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [SkyDogCon](http://www.skydogcon.com/) - Technology conference in Nashville.
 * [SECUINSIDE](http://secuinside.com) - Security Conference in [Seoul](https://en.wikipedia.org/wiki/Seoul).
 * [DefCamp](http://def.camp/) - Largest Security Conference in Eastern Europe, held annually in Bucharest, Romania.
-* [AppSecUSA](https://2016.appsecusa.org/) - Annual conference organized by OWASP.
+* [AppSecUSA](https://appsecusa.org/) - Annual conference organized by OWASP.
 * [BruCON](http://brucon.org) - Annual security conference in Belgium.
 * [Infosecurity Europe](http://www.infosecurityeurope.com/) - Europe's number one information security event, held in London, UK.
 * [Nullcon](http://nullcon.net/website/) - Annual conference in Delhi and Goa, India.


### PR DESCRIPTION
This commit fixes numerous CI build issues related to stale or broken
links. These include:

* Removal of Zoom username enumeration tool, covered by WPScan anyway.
* Removal of old Google dork database that is unmaintained/has vanished.
* Removal of `OSVDB.org` zone, which no longer resolves via DNS.
* Fix link to NoSQLmap tool (domain expired, use GitHub.com link now).
* Update link to Social Engineering in IT book from legacy URL.
* Update link to OWASP's AppSecUSA conference; now uses second-level domain.

Further, this commit simplifies the `.travis.yml` file in order to use a
plainer (more standard) certificates bundle. Two URLs have been added to
the whitelist: `www.shodan.io`, which returns a 403 Forbidden error when
accessed by Awesome Bot, and `www.mhprofessional.com`, which generates
an SSLv3 certificate validation error.

Prior to this commit, a custom SSL certificate bundle was generated and
then placed in the `/tmp` directory for use, but this is no longer
required as the latest `ca-certificates` bundle shipped with Ubuntu
contains the root certificates needed for the domains that once required
this custom bundle to be used.