### PR TITLE
Adding Hwacha to GNU/Linux utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Linux Exploit Suggester](https://github.com/PenturaLabs/Linux_Exploit_Suggester) - Heuristic reporting on potentially viable exploits for a given GNU/Linux system.
 * [Lynis](https://cisofy.com/lynis/) - Auditing tool for UNIX-based systems.
 * [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
+* [Hwacha](https://github.com/n00py/Hwacha) - Post-exploitation tool to quickly execute payloads on Linux systems. Can collect artifacts and execute payloads on multiple hosts at once via SSH. 
 
 ### macOS Utilities
 


### PR DESCRIPTION
Hwacha is a post-exploitation (credentials or keys obtained) tool that uses SSH to execute payloads or collect artifacts from one or multiple hosts at a time.