### PR TITLE
Add Decker orchestration framework to multi-paradigm frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [ExploitPack](https://github.com/juansacco/exploitpack) - Graphical tool for automating penetration tests that ships with many pre-packaged exploits.
 * [Pupy](https://github.com/n1nj4sec/pupy) - Cross-platform (Windows, Linux, macOS, Android) remote administration and post-exploitation tool.
 * [AutoSploit](https://github.com/NullArray/AutoSploit) - Automated mass exploiter, which collects target by employing the Shodan.io API and programmatically chooses Metasploit exploit modules based on the Shodan query.
+* [Decker](https://github.com/stevenaldinger/decker) - Penetration testing orchestration and automation framework, which allows writing declarative, reusable configurations capable of ingesting variables and using outputs of tools it has run as inputs to others.
 
 ### Network Vulnerability Scanners
 


### PR DESCRIPTION
https://github.com/stevenaldinger/decker
Decker allows writing declarative "penetration tests as code". It uses the same config language as Terraform and other Hashicorp tools and has a plugin based architecture so the usefulness of the framework will grow as more plugins become available. The [all-the-things](https://github.com/stevenaldinger/decker/blob/master/examples/all-the-things.hcl) example will take a target hostname and run web app scans such as SSL vulnerability and WAF detection as well as general info gathering, ftp, smtp, imap, vnc, mysql, and postgres scans if the relevant ports are found to be open in the nmap scan.
Docker images are also provided and the `stevenaldinger/decker:kali` image is recommended since it has a lot of tools preinstalled.