### PR TITLE
Add `shellpop`, remove trailing whitespace, fix minor grammar errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Physical Access Tools](#physical-access-tools)
   * [Side-channel Tools](#side-channel-tools)
   * [CTF Tools](#ctf-tools)
-  * [Penetration Testing Report Templates](#penetration-testing-report-templates)  
+  * [Penetration Testing Report Templates](#penetration-testing-report-templates)
   * [Code examples for Penetration Testing](#code-examples-for-penetration-testing)
 * [Books](#books)
   * [Penetration Testing Books](#penetration-testing-books)
@@ -210,7 +210,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [THC Hydra](https://github.com/vanhauser-thc/thc-hydra) - Online password cracking tool with built-in support for many network protocols, including HTTP, SMB, FTP, telnet, ICQ, MySQL, LDAP, IMAP, VNC, and more.
 * [IKEForce](https://github.com/SpiderLabs/ikeforce) - Command line IPSEC VPN brute forcing tool for Linux that allows group name/ID enumeration and XAUTH brute forcing capabilities.
 * [hping3](https://github.com/antirez/hping) - Network tool able to send custom TCP/IP packets.
-* [rshijack](https://github.com/kpcyrd/rshijack) - TCP connection hijacker, rust rewrite of shijack.
+* [rshijack](https://github.com/kpcyrd/rshijack) - TCP connection hijacker, Rust rewrite of `shijack`.
 
 #### Exfiltration Tools
 
@@ -386,7 +386,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Linux Exploit Suggester](https://github.com/PenturaLabs/Linux_Exploit_Suggester) - Heuristic reporting on potentially viable exploits for a given GNU/Linux system.
 * [Lynis](https://cisofy.com/lynis/) - Auditing tool for UNIX-based systems.
 * [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
-* [Hwacha](https://github.com/n00py/Hwacha) - Post-exploitation tool to quickly execute payloads on Linux systems. Can collect artifacts and execute payloads on multiple hosts at once via SSH. 
+* [Hwacha](https://github.com/n00py/Hwacha) - Post-exploitation tool to quickly execute payloads via SSH on one or more Linux systems simultaneously.
 
 ### macOS Utilities
 
@@ -510,6 +510,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [ctf-tools](https://github.com/zardus/ctf-tools) - Collection of setup scripts to install various security research tools easily and quickly deployable to new machines.
 * [Pwntools](https://github.com/Gallopsled/pwntools) - Rapid exploit development framework built for use in CTFs.
 * [RsaCtfTool](https://github.com/sourcekris/RsaCtfTool) - Decrypt data enciphered using weak RSA keys, and recover private keys from public keys using a variety of automated attacks.
+* [shellpop](https://github.com/0x00-0x00/shellpop) - Easily generate sophisticated reverse or bind shell commands to help you save time during penetration tests.
 
 ### Penetration Testing Report Templates
 


### PR DESCRIPTION
This commit adds a new utility, `shellpop`, which is a Python script
that is used to generate sophisticated shellcode in numerous languages.

It also removes trailing whitespace from several line items, likely
added by mistake, capitalizes the name of the programming language Rust,
and rephrases the description of Hwacha for clarity and conciseness.