### PR TITLE
General re-organization of some Tools sections, adds several tools.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Social Engineering Resources](#social-engineering-resources)
   * [Lock Picking Resources](#lock-picking-resources)
   * [Operating Systems](#operating-systems)
+  * [Penetration Testing Report Templates](#penetration-testing-report-templates)
+  * [Code examples for Penetration Testing](#code-examples-for-penetration-testing)
 * [Tools](#tools)
   * [Penetration Testing Distributions](#penetration-testing-distributions)
   * [Docker for Penetration Testing](#docker-for-penetration-testing)
@@ -48,8 +50,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Industrial Control and SCADA Systems](#industrial-control-and-scada-systems)
   * [Side-channel Tools](#side-channel-tools)
   * [CTF Tools](#ctf-tools)
-  * [Penetration Testing Report Templates](#penetration-testing-report-templates)
-  * [Code examples for Penetration Testing](#code-examples-for-penetration-testing)
+  * [Collaboration Tools](#collaboration-tools)
 * [Books](#books)
   * [Penetration Testing Books](#penetration-testing-books)
   * [Hackers Handbook Series](#hackers-handbook-series)
@@ -114,6 +115,16 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [SIFT](https://digital-forensics.sans.org/community/downloads) - Forensic workstation made by SANS.
 * [Tails](https://tails.boum.org/) - Live OS aimed at preserving privacy and anonymity.
 * [Qubes OS](https://www.qubes-os.org) - High-security Operating System providing strict application isolation.
+
+### Penetration Testing Report Templates
+
+* [Public Pentesting Reports](https://github.com/juliocesarfort/public-pentesting-reports) - Curated list of public penetration test reports released by several consulting firms and academic security groups.
+* [T&VS Pentesting Report Template](https://www.testandverification.com/wp-content/uploads/template-penetration-testing-report-v03.pdf) - Pentest report template provided by Test and Verification Services, Ltd.
+* [Web Application Security Assessment Report Template](http://lucideus.com/pdf/stw.pdf) - Sample Web application security assessment reporting template provided by Lucideus.
+
+### Code examples for Penetration Testing
+
+* [goHackTools](https://github.com/dreddsa5dies/goHackTools) - Hacker tools on Go (Golang).
 
 ## Tools
 
@@ -221,6 +232,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [pwnat](https://github.com/samyk/pwnat) - Punches holes in firewalls and NATs.
 * [tgcd](http://tgcd.sourceforge.net/) - Simple Unix network utility to extend the accessibility of TCP/IP based network services beyond firewalls.
 * [Iodine](https://code.kryo.se/iodine/) - Tunnel IPv4 data through a DNS server; useful for exfiltration from networks where Internet access is firewalled, but DNS queries are allowed.
+* [Cloakify](https://github.com/TryCatchHCF/Cloakify) - Textual steganography toolkit that converts any filetype into lists of everyday strings.
 
 #### Network Reconnaissance Tools
 
@@ -526,15 +538,9 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [RsaCtfTool](https://github.com/sourcekris/RsaCtfTool) - Decrypt data enciphered using weak RSA keys, and recover private keys from public keys using a variety of automated attacks.
 * [shellpop](https://github.com/0x00-0x00/shellpop) - Easily generate sophisticated reverse or bind shell commands to help you save time during penetration tests.
 
-### Penetration Testing Report Templates
+### Collaboration Tools
 
-* [Public Pentesting Reports](https://github.com/juliocesarfort/public-pentesting-reports) - Curated list of public penetration test reports released by several consulting firms and academic security groups.
-* [T&VS Pentesting Report Template](https://www.testandverification.com/wp-content/uploads/template-penetration-testing-report-v03.pdf) - Pentest report template provided by Test and Verification Services, Ltd.
-* [Web Application Security Assessment Report Template](http://lucideus.com/pdf/stw.pdf) - Sample Web application security assessment reporting template provided by Lucideus.
-
-### Code examples for Penetration Testing
-
-* [goHackTools](https://github.com/dreddsa5dies/goHackTools) - Hacker tools on Go (Golang).
+* [RedELK](https://github.com/outflanknl/RedELK) - Track and alarm about Blue Team activities while providing better usability in long term offensive operations.
 
 ## Books
 


### PR DESCRIPTION
This commit makes a substantial change by moving two sections that were
previously in "Tools" into the "Online Resources" category instead.
Specifically, the "Penetration Testing Report Templates" and "Code
examples for Penetration Testing" sections, each of which contained
references to documents rather than immediately-usable software, were
moved out of the "Tools" category. This was done because there is now a
clear distinction between "places to go to get more information about a
topic" (a resource) and "software to download that is immediately usable
in a pentest" (a tool).

Additionally, this commit adds a new section of Tools for pentests
tentatively called "Collaboration Tools" and adds RedELK, a Red Team's
SIEM, to that section. RedELK is an example of a multiple teamserver
analysis framework intended for use during long-term engagements for
keeping tabs on Blue Team activities, so it is not exactly like any
other tool in this list.

Finally, another tool (Cloakify) was added to the data exfiltration
section.