### PR TITLE
Address numerous Awesome linter errors for sindresorhus/awesome#1366 PR.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Awesome Penetration Testing [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
+# Awesome Penetration Testing [![Awesome](https://awesome.re/badge-flat2.svg)](https://awesome.re)
 
 > A collection of awesome penetration testing resources.
-
-**[This project is supported by Netsparker Web Application Security Scanner](https://www.netsparker.com/?utm_source=github.com&utm_content=awesome+penetration+testing&utm_medium=referral&utm_campaign=generic+advert)**
 
 [Penetration testing](https://en.wikipedia.org/wiki/Penetration_test) is the practice of launching authorized, simulated attacks against computer systems and their physical infrastructure to expose potential security weaknesses and vulnerabilities.
 
 Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Please check the [Contributing Guidelines](CONTRIBUTING.md) for more details. This work is licensed under a [Creative Commons Attribution 4.0 International License](https://creativecommons.org/licenses/by/4.0/).
+
+[This project is supported by Netsparker Web Application Security Scanner](https://www.netsparker.com/?utm_source=github.com&utm_content=awesome+penetration+testing&utm_medium=referral&utm_campaign=generic+advert)
 
 ## Contents
 
@@ -696,7 +696,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 
 ## Information Security Magazines
 
-* [2600: The Hacker Quarterly](https://www.2600.com/Magazine/DigitalEditions) - American publication about technology and computer "underground."
+* [2600: The Hacker Quarterly](https://www.2600.com/Magazine/DigitalEditions) - American publication about technology and computer "underground" culture.
 * [Phrack Magazine](http://www.phrack.org/) - By far the longest running hacker zine.
 
 ## Awesome Lists
@@ -736,7 +736,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Android Exploits](https://github.com/sundaysec/Android-Exploits) - Guide on Android Exploitation and Hacks.
 * [Serverless Security](https://github.com/puresec/awesome-serverless-security/) - A curated list of awesome serverless security resources such as (e)books, articles, whitepapers, blogs and research papers.
 
-# License
+## License
 
 [![CC-BY](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/by.svg)](https://creativecommons.org/licenses/by/4.0/)
 


### PR DESCRIPTION
This commit removes the bolding from the Netsparker referral link
because it lints as a heading. (The referral URL itself was not
deleted.) It also adds the word `culture` at the end of the 2600 list
item so that line item won't end in a quotation mark, but a period (as
the pedantic linter requires). This commit also fixes the headline level
for the License section and uses the new Awesome badge SVG sources.