### PR TITLE
Add new Android section and three tools to it, fix a couple build errors.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,4 @@ install:
   - gem install awesome_bot
 
 script:
-  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,netsparker.com,www.shodan.io,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org"
+  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,netsparker.com,www.shodan.io,www.parrotsec.org,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Static Analyzers](#static-analyzers)
 * [Vulnerability Databases](#vulnerability-databases)
 * [Web Exploitation](#web-exploitation)
+* [Android Utilities](#android-utilities)
 * [Windows Utilities](#windows-utilities)
 * [macOS Utilities](#macos-utilities)
 
@@ -725,6 +726,12 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [wafw00f](https://github.com/EnableSecurity/wafw00f) - Identifies and fingerprints Web Application Firewall (WAF) products.
 * [webscreenshot](https://github.com/maaaaz/webscreenshot) - Simple script to take screenshots of websites from a list of sites.
 * [weevely3](https://github.com/epinna/weevely3) - Weaponized PHP-based web shell.
+
+## Android Utilities
+
+* [Android Open Pwn Project (AOPP)](https://www.pwnieexpress.com/aopp) - Variant of the Android Open Source Project (AOSP), called Pwnix, is built from the ground up for network hacking and pentesting.
+* [cSploit](https://www.csploit.org/) - Advanced IT security professional toolkit on Android featuring an integrated Metasploit daemon and MITM capabilities.
+* [Fing](https://www.fing.com/products/fing-app/) - Network scanning and host enumeration app that performs NetBIOS, UPnP, Bonjour, SNMP, and various other advanced device fingerprinting techniques.
 
 ## Windows Utilities
 

--- a/README.md
+++ b/README.md
@@ -608,7 +608,7 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [Evan's Debugger](http://www.codef00.com/projects#debugger) - OllyDbg-like debugger for GNU/Linux.
 * [Frida](https://www.frida.re/) - Dynamic instrumentation toolkit for developers, reverse-engineers, and security researchers.
 * [Ghidra](https://www.ghidra-sre.org/) - Suite of free software reverse engineering tools developed by NSA's Research Directorate originally exposed in WikiLeaks's "Vault 7" publication and now maintained as open source software.
-* [Immunity Debugger](http://debugger.immunityinc.com/) - Powerful way to write exploits and analyze malware.
+* [Immunity Debugger](https://immunityinc.com/products/debugger/) - Powerful way to write exploits and analyze malware.
 * [Interactive Disassembler (IDA Pro)](https://www.hex-rays.com/products/ida/) - Proprietary multi-processor disassembler and debugger for Windows, GNU/Linux, or macOS; also has a free version, [IDA Free](https://www.hex-rays.com/products/ida/support/download_freeware.shtml).
 * [Medusa](https://github.com/wisk/medusa) - Open source, cross-platform interactive disassembler.
 * [OllyDbg](http://www.ollydbg.de/) - x86 debugger for Windows binaries that emphasizes binary code analysis.


### PR DESCRIPTION
This PR merges work on a new section for Android-based software, which includes the cSploit integrated Metasploit app, the AOPP custom ROM build system and software ports, and the Fing network scanner.

Additionally, a couple of commits work on fixing Travis CI build errors. This includes adding `www.parrot.org` to the URL whitelist due to their new use of the Cloudflare WAF, and an updated URL for the Immunity Debugger line item.