### PR TITLE
Adding 'archstrike-docker' to Awesome List

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [Official WPScan](https://hub.docker.com/r/wpscanteam/wpscan/) - `docker pull wpscanteam/wpscan`.
 * [Security Ninjas](https://hub.docker.com/r/opendns/security-ninjas/) - `docker pull opendns/security-ninjas`.
 * [docker-metasploit](https://hub.docker.com/r/phocean/msf/) - `docker pull phocean/msf`.
+* [archstrike-docker](https://hub.docker.com/r/vltraheaven/archstrike-docker/) - `docker pull vltraheaven/archstrike-docker`.
 
 ## File Format Analysis Tools
 


### PR DESCRIPTION
Request to add 'archstrike-docker', a penetration testing docker container based on the 'archlinux/base' (https://hub.docker.com/r/archlinux/base/) docker container with ArchStrike (https://github.com/ArchStrike/ArchStrike) pacman repos enabled.