### PR TITLE
Add duplicut, C Tool to remove duplicates, without changing the order…

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 * [BruteForce Wallet](https://github.com/glv2/bruteforce-wallet) - Find the password of an encrypted wallet file (i.e. `wallet.dat`).
 * [CeWL](https://digi.ninja/projects/cewl.php) - Generates custom wordlists by spidering a target's website and collecting unique words.
+* [duplicut](https://github.com/nil0x42/duplicut) - Quickly remove duplicates, without changing the order, and without getting OOM on huge wordlists.
 * [Hashcat](http://hashcat.net/hashcat/) - The more fast hash cracker.
 * [hate_crack](https://github.com/trustedsec/hate_crack) - Tool for automating cracking methodologies through Hashcat.
 * [JWT Cracker](https://github.com/lmammino/jwt-cracker) - Simple HS256 JSON Web Token (JWT) token brute force cracker.


### PR DESCRIPTION
…, and without getting OOM on huge wordlists.

duplicut is a C tool, highly optimized for a single task:
Removing duplicate entries from a wordlist, without changing the order, and without getting OOM on huge wordlists whose size exceeds available memory.

It's trivial to remove duplicates by sorting, but duplicut is the only tool capable of removing them without changing the order, to assist the creation of statictically optimized wordlists for password cracking purposes.