### PR TITLE
Add National Cyber Summit Conference to the Conference List

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [Hackfest](https://hackfest.ca) - Largest hacking conference in Canada.
 * [Infosecurity Europe](http://www.infosecurityeurope.com/) - Europe's number one information security event, held in London, UK.
 * [LayerOne](http://www.layerone.org/) - Annual US security conference held every spring in Los Angeles.
+* [National Cyber Summit](https://www.nationalcybersummit.com/) - Annual US security conference and Capture the Flag event, held in Huntsville, Alabama, USA.
 * [Nullcon](http://nullcon.net/website/) - Annual conference in Delhi and Goa, India.
 * [PhreakNIC](http://phreaknic.info/) - Technology conference held annually in middle Tennessee.
 * [RSA Conference USA](https://www.rsaconference.com/) - Annual security conference in San Francisco, California, USA.


### PR DESCRIPTION
I added the National Cyber Summit Conference to the Conference List due to it being a great resource for learning about new technologies and talking to experts, but also because it has an annual Capture the Flag event.