### PR TITLE
Add SIET, tool for manipulating insecure Cisco Smart Install switches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Praeda](http://h.foofus.net/?page_id=218) - Automated multi-function printer data harvester for gathering usable data during security assessments.
 * [Printer Exploitation Toolkit (PRET)](https://github.com/RUB-NDS/PRET) - Tool for printer security testing capable of IP and USB connectivity, fuzzing, and exploitation of PostScript, PJL, and PCL printer language features.
 * [SPARTA](https://sparta.secforce.com/) - Graphical interface offering scriptable, configurable access to existing network infrastructure scanning and enumeration tools.
+* [Smart Install Exploitation Tool (SIET)](https://github.com/Sab0tag3d/SIET) - Scripts for identifying Cisco Smart Install-enabled switches on a network and then manipulating them.
 * [THC Hydra](https://github.com/vanhauser-thc/thc-hydra) - Online password cracking tool with built-in support for many network protocols, including HTTP, SMB, FTP, telnet, ICQ, MySQL, LDAP, IMAP, VNC, and more.
 * [Zarp](https://github.com/hatRiot/zarp) - Network attack tool centered around the exploitation of local networks.
 * [dnstwist](https://github.com/elceef/dnstwist) - Domain name permutation engine for detecting typo squatting, phishing and corporate espionage.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [OnionScan](https://onionscan.org/) - Tool for investigating the Dark Web by finding operational security issues introduced by Tor hidden service operators.
 * [Tor](https://www.torproject.org/) - Free software and onion routed overlay network that helps you defend against traffic analysis.
 * [What Every Browser Knows About You](http://webkay.robinlinus.com/) - Comprehensive detection page to test your own Web browser's configuration for privacy and identity leaks.
-* [dos-over-tor](https://github.com/zacscott/dos-over-tor) - Proof of concept denial of service over Tor stress test tool.
+* [dos-over-tor](https://github.com/skizap/dos-over-tor) - Proof of concept denial of service over Tor stress test tool.
 * [kalitorify](https://github.com/brainfuckSec/kalitorify) - Transparent proxy through Tor for Kali Linux OS.
 
 ## Anti-virus Evasion Tools


### PR DESCRIPTION
This pull request also includes a fix for the `dos-over-tor` tool which otherwise returns an HTTP 404 Not Found error.