### PR TITLE
Subcategorize "Conferences" section by continent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [DeepSec](https://deepsec.net/) - Security Conference in Vienna, Austria.
 * [DefCamp](http://def.camp/) - Largest Security Conference in Eastern Europe, held annually in Bucharest, Romania.
 * [FSec](http://fsec.foi.hr) - FSec - Croatian Information Security Gathering in Varaždin, Croatia.
-* [Hack.lu](https://2016.hack.lu/) - Annual conference held in Luxembourg.
+* [Hack.lu](https://hack.lu/) - Annual conference held in Luxembourg.
 * [Infosecurity Europe](http://www.infosecurityeurope.com/) - Europe's number one information security event, held in London, UK.
 * [SteelCon](https://www.steelcon.info/) - Security conference in Sheffield UK.
 * [Swiss Cyber Storm](https://www.swisscyberstorm.com/) - Annual security conference in Lucerne, Switzerland.
@@ -242,7 +242,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 ### Zealandia
 
-* [CHCon](https://2016.chcon.nz/) - Christchurch Hacker Con, Only South Island of New Zealand hacker con.
+* [CHCon](https://chcon.nz) - Christchurch Hacker Con, Only South Island of New Zealand hacker con.
 
 ## Docker Containers
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [CTF Tools](#ctf-tools)
 * [Collaboration Tools](#collaboration-tools)
 * [Conferences and Events](#conferences-and-events)
+  * [Asia](#asia)
+  * [Europe](#europe)
+  * [North America](#north-america)
+  * [South America](#south-america)
+  * [Zealandia](#zealandia)
 * [Docker Containers](#docker-containers)
   * [Docker Containers of Intentionally Vulnerable Systems](#docker-containers-of-intentionally-vulnerable-systems)
   * [Docker Containers of Penetration Testing Distributions and Tools](#docker-containers-of-penetration-testing-distributions-and-tools)
@@ -188,41 +193,56 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 ## Conferences and Events
 
-* [44Con](https://44con.com/) - Annual Security Conference held in London.
-* [AppSecUSA](https://appsecusa.org/) - Annual conference organized by OWASP.
 * [BSides](http://www.securitybsides.com/) - Framework for organising and holding security conferences.
+
+### Asia
+
+* [HITB](https://conference.hitb.org/) - Deep-knowledge security conference held in Malaysia and The Netherlands.
+* [Nullcon](http://nullcon.net/website/) - Annual conference in Delhi and Goa, India.
+* [SECUINSIDE](http://secuinside.com) - Security Conference in Seoul.
+
+### Europe
+
+* [44Con](https://44con.com/) - Annual Security Conference held in London.
 * [BalCCon](https://www.balccon.org) - Balkan Computer Congress, annually held in Novi Sad, Serbia.
-* [Black Hat](http://www.blackhat.com/) - Annual security conference in Las Vegas.
 * [BruCON](http://brucon.org) - Annual security conference in Belgium.
 * [CCC](https://events.ccc.de/congress/) - Annual meeting of the international hacker scene in Germany.
-* [CHCon](https://2016.chcon.nz/) - Christchurch Hacker Con, Only South Island of New Zealand hacker con.
-* [CarolinaCon](https://carolinacon.org/) - Infosec conference, held annually in North Carolina.
-* [DEF CON](https://www.defcon.org/) - Annual hacker convention in Las Vegas.
 * [DeepSec](https://deepsec.net/) - Security Conference in Vienna, Austria.
 * [DefCamp](http://def.camp/) - Largest Security Conference in Eastern Europe, held annually in Bucharest, Romania.
-* [DerbyCon](https://www.derbycon.com/) - Annual hacker conference based in Louisville.
-* [Ekoparty](http://www.ekoparty.org) - Largest Security Conference in Latin America, held annually in Buenos Aires, Argentina.
 * [FSec](http://fsec.foi.hr) - FSec - Croatian Information Security Gathering in Varaždin, Croatia.
-* [HITB](https://conference.hitb.org/) - Deep-knowledge security conference held in Malaysia and The Netherlands.
 * [Hack.lu](https://2016.hack.lu/) - Annual conference held in Luxembourg.
+* [Infosecurity Europe](http://www.infosecurityeurope.com/) - Europe's number one information security event, held in London, UK.
+* [SteelCon](https://www.steelcon.info/) - Security conference in Sheffield UK.
+* [Swiss Cyber Storm](https://www.swisscyberstorm.com/) - Annual security conference in Lucerne, Switzerland.
+* [Troopers](https://www.troopers.de) - Annual international IT Security event with workshops held in Heidelberg, Germany.
+
+### North America
+
+* [AppSecUSA](https://appsecusa.org/) - Annual conference organized by OWASP.
+* [Black Hat](http://www.blackhat.com/) - Annual security conference in Las Vegas.
+* [CarolinaCon](https://carolinacon.org/) - Infosec conference, held annually in North Carolina.
+* [DEF CON](https://www.defcon.org/) - Annual hacker convention in Las Vegas.
+* [DerbyCon](https://www.derbycon.com/) - Annual hacker conference based in Louisville.
 * [Hackers Next Door](https://hnd.techlearningcollective.com/) - Cybersecurity and social technology conference held in New York City.
 * [Hackers On Planet Earth (HOPE)](https://hope.net/) - Semi-annual conference held in New York City.
 * [Hackfest](https://hackfest.ca) - Largest hacking conference in Canada.
-* [Infosecurity Europe](http://www.infosecurityeurope.com/) - Europe's number one information security event, held in London, UK.
 * [LayerOne](http://www.layerone.org/) - Annual US security conference held every spring in Los Angeles.
 * [National Cyber Summit](https://www.nationalcybersummit.com/) - Annual US security conference and Capture the Flag event, held in Huntsville, Alabama, USA.
-* [Nullcon](http://nullcon.net/website/) - Annual conference in Delhi and Goa, India.
 * [PhreakNIC](http://phreaknic.info/) - Technology conference held annually in middle Tennessee.
 * [RSA Conference USA](https://www.rsaconference.com/) - Annual security conference in San Francisco, California, USA.
-* [SECUINSIDE](http://secuinside.com) - Security Conference in [Seoul](https://en.wikipedia.org/wiki/Seoul).
 * [ShmooCon](http://shmoocon.org/) - Annual US East coast hacker convention.
 * [SkyDogCon](http://www.skydogcon.com/) - Technology conference in Nashville.
-* [SteelCon](https://www.steelcon.info/) - Security conference in Sheffield UK.
-* [SummerCon](http://www.summercon.org/) - One of the oldest hacker conventions, held during Summer.
-* [Swiss Cyber Storm](https://www.swisscyberstorm.com/) - Annual security conference in Lucerne, Switzerland.
+* [SummerCon](https://www.summercon.org/) - One of the oldest hacker conventions in America, held during Summer.
 * [ThotCon](http://thotcon.org/) - Annual US hacker conference held in Chicago.
-* [Troopers](https://www.troopers.de) - Annual international IT Security event with workshops held in Heidelberg, Germany.
 * [Virus Bulletin Conference](https://www.virusbulletin.com/conference/index) - Annual conference going to be held in Denver, USA for 2016.
+
+### South America
+
+* [Ekoparty](http://www.ekoparty.org) - Largest Security Conference in Latin America, held annually in Buenos Aires, Argentina.
+
+### Zealandia
+
+* [CHCon](https://2016.chcon.nz/) - Christchurch Hacker Con, Only South Island of New Zealand hacker con.
 
 ## Docker Containers
 


### PR DESCRIPTION
This PR proposes a by-continent categorization scheme for the "Conferences and Events" section because that section is getting somewhat long and unwieldy. I am suggesting "by continent" as a subcategorization scheme because it feels appropriately sized and also offers visibility into which areas of the world are perhaps underrepresented in this list.