### PR TITLE
Add subbrute, recategorize some tools, fixup Travis build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - gem install awesome_bot
 
 script:
-  - awesome_bot README.md --allow-redirect --white-list "mvfjfugdwgc5uwho.onion,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org,www.amazon.com,packetstormsecurity.com"
+  - awesome_bot README.md --allow-redirect --white-list "creativecommons.org,mvfjfugdwgc5uwho.onion,www.mhprofessional.com,www.derbycon.com,ghostproject.fr,www.zoomeye.org,www.amazon.com,packetstormsecurity.com,www.shodan.io"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - gem install awesome_bot
 
 script:
-  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,netsparker.com,www.shodan.io,www.parrotsec.org,nostarch.com,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org,www.amazon.com,packetstormsecurity.com"
+  - awesome_bot README.md --allow-redirect --white-list "mvfjfugdwgc5uwho.onion,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org,www.amazon.com,packetstormsecurity.com"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,10 @@
 ---
+version: ~> 1.0
+
+os: linux
+dist: bionic
+
 language: ruby
-sudo: required
-rvm:
-  - 2.4.1
 
 install:
   - sudo apt update --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - gem install awesome_bot
 
 script:
-  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,netsparker.com,www.shodan.io,www.parrotsec.org,nostarch.com,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org"
+  - awesome_bot README.md --allow-redirect --white-list "www.0day.today,mvfjfugdwgc5uwho.onion,creativecommons.org,netsparker.com,www.shodan.io,www.parrotsec.org,nostarch.com,www.mhprofessional.com,ghostproject.fr,www.zoomeye.org,www.amazon.com,packetstormsecurity.com"

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 ### DDoS Tools
 
-* [Anevicon](https://github.com/Gymmasssorla/anevicon) - Powerful UDP-based load generator, written in Rust.
+* [Anevicon](https://github.com/rozgo/anevicon) - Powerful UDP-based load generator, written in Rust.
 * [HOIC](https://sourceforge.net/projects/high-orbit-ion-cannon/) - Updated version of Low Orbit Ion Cannon, has 'boosters' to get around common counter measures.
 * [JS LOIC](http://metacortexsecurity.com/tools/anon/LOIC/LOICv1.html) - JavaScript in-browser version of LOIC.
 * [LOIC](https://github.com/NewEraCracker/LOIC/) - Open source network stress tool for Windows.
@@ -564,7 +564,6 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 * [CertGraph](https://github.com/lanrat/certgraph) - Crawls a domain's SSL/TLS certificates for its certificate alternative names.
 * [GhostProject](https://ghostproject.fr/) - Searchable database of billions of cleartext passwords, partially visible for free.
-* [Intel Techniques](https://inteltechniques.com/menu.html) - Collection of OSINT tools. Menu on the left can be used to navigate through the categories.
 * [NetBootcamp OSINT Tools](http://netbootcamp.org/osinttools/) - Collection of OSINT links and custom Web interfaces to other services.
 * [OSINT Framework](http://osintframework.com/) - Collection of various OSINT tools broken out by category.
 * [WiGLE.net](https://wigle.net/) - Information about wireless networks world-wide, with user-friendly desktop and web applications.

--- a/README.md
+++ b/README.md
@@ -378,9 +378,11 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 ### Network Reconnaissance Tools
 
 * [ACLight](https://github.com/cyberark/ACLight) - Script for advanced discovery of sensitive Privileged Accounts - includes Shadow Admins.
+* [AQUATONE](https://github.com/michenriksen/aquatone) - Subdomain discovery tool utilizing various open sources producing a report that can be used as input to other tools.
 * [CloudFail](https://github.com/m0rtem/CloudFail) - Unmask server IP addresses hidden behind Cloudflare by searching old database records and detecting misconfigured DNS.
 * [DNSDumpster](https://dnsdumpster.com/) - Online DNS recon and search service.
 * [Mass Scan](https://github.com/robertdavidgraham/masscan) - TCP port scanner, spews SYN packets asynchronously, scanning entire Internet in under 5 minutes.
+* [OWASP Amass](https://github.com/OWASP/Amass) - Subdomain enumeration via scraping, web archives, brute forcing, permutations, reverse DNS sweeping, TLS certificates, passive DNS data sources, etc.
 * [ScanCannon](https://github.com/johnnyxmas/ScanCannon) - Python script to quickly enumerate large networks by calling `masscan` to quickly identify open ports and then `nmap` to gain details on the systems/services on those ports.
 * [XRay](https://github.com/evilsocket/xray) - Network (sub)domain discovery and reconnaissance automation tool.
 * [dnsenum](https://github.com/fwaeytens/dnsenum/) - Perl script that enumerates DNS information from a domain, attempts zone transfers, performs a brute force dictionary style attack, and then performs reverse look-ups on the results.
@@ -393,6 +395,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [passivedns](https://github.com/gamelinux/passivedns) - Network sniffer that logs all DNS server replies for use in a passive DNS setup.
 * [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP.
 * [smbmap](https://github.com/ShawnDEvans/smbmap) - Handy SMB enumeration tool.
+* [subbrute](https://github.com/TheRook/subbrute) - DNS meta-query spider that enumerates DNS records, and subdomains.
 * [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.
 
 ### Protocol Analyzers and Sniffers
@@ -530,9 +533,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 ### Network device discovery tools
 
-* [AQUATONE](https://github.com/michenriksen/aquatone) - Subdomain discovery tool utilizing various open sources producing a report that can be used as input to other tools.
 * [Censys](https://www.censys.io/) - Collects data on hosts and websites through daily ZMap and ZGrab scans.
-* [OWASP Amass](https://github.com/OWASP/Amass) - Subdomain enumeration via scraping, web archives, brute forcing, permutations, reverse DNS sweeping, TLS certificates, passive DNS data sources, etc.
 * [Shodan](https://www.shodan.io/) - World's first search engine for Internet-connected devices.
 * [ZoomEye](https://www.zoomeye.org/) - Search engine for cyberspace that lets the user find specific network components.
 

--- a/README.md
+++ b/README.md
@@ -463,7 +463,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 * [celerystalk](https://github.com/sethsec/celerystalk) - Asynchronous enumeration and vulnerability scanner that "runs all the tools on all the hosts" in a configurable manner.
 * [Nessus](https://www.tenable.com/products/nessus-vulnerability-scanner) - Commercial vulnerability management, configuration, and compliance assessment platform, sold by Tenable.
-* [Netsparker Application Security Scanner](https://www.netsparker.com/) - Application security scanner to automatically find security flaws.
+* [Netsparker Application Security Scanner](https://www.netsparker.com/pricing/) - Application security scanner to automatically find security flaws.
 * [Nexpose](https://www.rapid7.com/products/nexpose/) - Commercial vulnerability and risk management assessment engine that integrates with Metasploit, sold by Rapid7.
 * [OpenVAS](http://www.openvas.org/) - Free software implementation of the popular Nessus vulnerability assessment system.
 * [Vuls](https://github.com/future-architect/vuls) - Agentless vulnerability scanner for GNU/Linux and FreeBSD, written in Go.
@@ -473,7 +473,6 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [ACSTIS](https://github.com/tijme/angularjs-csti-scanner) - Automated client-side template injection (sandbox escape/bypass) detection for AngularJS.
 * [Arachni](http://www.arachni-scanner.com/) - Scriptable framework for evaluating the security of web applications.
 * [JCS](https://github.com/TheM4hd1/JCS) - Joomla Vulnerability Component Scanner with automatic database updater from exploitdb and packetstorm.
-* [Netsparker Application Security Scanner](https://www.netsparker.com/) - Application security scanner to automatically find security flaws.
 * [Nikto](https://cirt.net/nikto2) - Noisy but fast black box web server and web application vulnerability scanner.
 * [SQLmate](https://github.com/UltimateHackers/sqlmate) - Friend of `sqlmap` that identifies SQLi vulnerabilities based on a given dork and (optional) website.
 * [SecApps](https://secapps.com/) - In-browser web application security testing suite.
@@ -644,7 +643,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Buscador](https://inteltechniques.com/buscador/) - GNU/Linux virtual machine that is pre-configured for online investigators.
 * [Kali](https://www.kali.org/) - Rolling Debian-based GNU/Linux distribution designed for penetration testing and digital forensics.
 * [Network Security Toolkit (NST)](http://networksecuritytoolkit.org/) - Fedora-based GNU/Linux bootable live Operating System designed to provide easy access to best-of-breed open source network security applications.
-* [Parrot](https://www.parrotsec.org/) - Distribution similar to Kali, with support for multiple hardware architectures.
+* [Parrot](https://parrotlinux.org/) - Distribution similar to Kali, with support for multiple hardware architectures.
 * [PentestBox](https://pentestbox.org/) - Open source pre-configured portable penetration testing environment for the Windows Operating System.
 * [The Pentesters Framework](https://github.com/trustedsec/ptf) - Distro organized around the Penetration Testing Execution Standard (PTES), providing a curated collection of utilities that omits less frequently used utilities.
 


### PR DESCRIPTION
This PR fixes many issues with the Travis CI build, ultimately removing a number of whitelisted URLs in favor of updated link content. Along that line, some links were removed (Intel Techniques no longer exists), some were updated (links that were 404'ing have been updated), etc.

AQUATONE and OWASP Amass have been recategorized as network recon tools, a new tool (subbrute) was added to that same section, and the Travis build environment uses an updated Travis CI configuration file with a more modern default Ruby installation.