### PR TITLE
Amazon.com says HTTP 503 often, so allow that but do not whitelist.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,4 +12,4 @@ install:
   - gem install awesome_bot
 
 script:
-  - awesome_bot README.md --allow-redirect --white-list "creativecommons.org,mvfjfugdwgc5uwho.onion,www.mhprofessional.com,www.derbycon.com,ghostproject.fr,www.zoomeye.org,www.amazon.com,packetstormsecurity.com,www.shodan.io"
+  - awesome_bot README.md --allow-redirect --allow 503 --white-list "creativecommons.org,mvfjfugdwgc5uwho.onion,www.mhprofessional.com,www.derbycon.com,www.zoomeye.org,packetstormsecurity.com,www.shodan.io"


### PR DESCRIPTION
This PR suggests allowing HTTP 503 Service Unavailable errors because of how frequently Amazon.com returns these errors to `awesome_bot`. Additionally, the `ghostproject.fr` domain, which was previously whitelisted, also returns this error due to their Cloudflare configuration.

I suggest that by allowing 503 errors, which are *usually* indications of temporary outages rather than permanent problems, we can shorten the awesome_bot whitelist, allow the Travis build to succeed, and yet still maintain an accurate view of link rot.