### PR TITLE
Add PSKracker, remove DWF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [CXSecurity](https://cxsecurity.com/) - Archive of published CVE and Bugtraq software vulnerabilities cross-referenced with a Google dork database for discovering the listed vulnerability.
 * [China National Vulnerability Database (CNNVD)](http://www.cnnvd.org.cn/) - Chinese government-run vulnerability database analoguous to the United States's CVE database hosted by Mitre Corporation.
 * [Common Vulnerabilities and Exposures (CVE)](https://cve.mitre.org/) - Dictionary of common names (i.e., CVE Identifiers) for publicly known security vulnerabilities.
-* [Distributed Weakness Filing (DWF)](https://distributedweaknessfiling.org/) - Federated CNA (CVE Number Authority) mirroring MITRE's CVE database and offering additional CVE-equivalent numbers to otherwise out-of-scope vulnerability disclosures.
 * [Exploit-DB](https://www.exploit-db.com/) - Non-profit project hosting exploits for software vulnerabilities, provided as a public service by Offensive Security.
 * [Full-Disclosure](http://seclists.org/fulldisclosure/) - Public, vendor-neutral forum for detailed discussion of vulnerabilities, often publishes details before many other sources.
 * [HPI-VDB](https://hpi-vdb.de/) - Aggregator of cross-referenced software vulnerabilities offering free-of-charge API access, provided by the Hasso-Plattner Institute, Potsdam.

--- a/README.md
+++ b/README.md
@@ -452,6 +452,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Fluxion](https://github.com/FluxionNetwork/fluxion) - Suite of automated social engineering based WPA attacks.
 * [KRACK Detector](https://github.com/securingsam/krackdetector) - Detect and prevent KRACK attacks in your network.
 * [Kismet](https://kismetwireless.net/) - Wireless network detector, sniffer, and IDS.
+* [PSKracker](https://github.com/soxrok2212/PSKracker) - Collection of WPA/WPA2/WPS default algorithms, password generators, and PIN generators written in C.
 * [pwnagotchi](https://github.com/evilsocket/pwnagotchi) - Deep reinforcement learning based AI that learns from the Wi-Fi environment and instruments BetterCAP in order to maximize the WPA key material captured.
 * [Reaver](https://code.google.com/archive/p/reaver-wps) - Brute force attack against WiFi Protected Setup.
 * [WiFi-Pumpkin](https://github.com/P0cL4bs/WiFi-Pumpkin) - Framework for rogue Wi-Fi access point attack.


### PR DESCRIPTION
PSKracker is a WPA/WPA2/WPS cracker for pentesters. The Distributed Weakness Filing project was [terminated by the creator on March 7th, 2019](https://twitter.com/kurtseifried/status/1103858442479910913), just over a year ago. Now their infrastructure is returning HTTP error codes that fail the build. This pull request includes a commit that removes the DWF project from this list.