### PR TITLE
Reorganization of sections, consistency fixes across headings and contents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 
 ## Contents
 
+* [Android Utilities](#android-utilities)
 * [Anonymity Tools](#anonymity-tools)
+  * [Tor Tools](#tor-tools)
 * [Anti-virus Evasion Tools](#anti-virus-evasion-tools)
 * [Books](#books)
   * [Defensive Programming Books](#defensive-programming-books)
@@ -33,15 +35,17 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Docker Containers](#docker-containers)
   * [Docker Containers of Intentionally Vulnerable Systems](#docker-containers-of-intentionally-vulnerable-systems)
   * [Docker Containers of Penetration Testing Distributions and Tools](#docker-containers-of-penetration-testing-distributions-and-tools)
+* [Exfiltration Tools](#exfiltration-tools)
+* [Exploit Development Tools](#exploit-development-tools)
 * [File Format Analysis Tools](#file-format-analysis-tools)
 * [GNU/Linux Utilities](#gnulinux-utilities)
 * [Hash Cracking Tools](#hash-cracking-tools)
 * [Hex Editors](#hex-editors)
 * [Industrial Control and SCADA Systems](#industrial-control-and-scada-systems)
+* [macOS Utilities](#macos-utilities)
 * [Multi-paradigm Frameworks](#multi-paradigm-frameworks)
 * [Network Tools](#network-tools)
   * [DDoS Tools](#ddos-tools)
-  * [Exfiltration Tools](#exfiltration-tools)
   * [Network Reconnaissance Tools](#network-reconnaissance-tools)
   * [Protocol Analyzers and Sniffers](#protocol-analyzers-and-sniffers)
   * [Network Traffic Replay and Editing Tools](#network-traffic-replay-and-editing-tools)
@@ -76,21 +80,31 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Side-channel Tools](#side-channel-tools)
 * [Social Engineering Tools](#social-engineering-tools)
 * [Static Analyzers](#static-analyzers)
+* [Steganography Tools](#steganography-tools)
 * [Vulnerability Databases](#vulnerability-databases)
 * [Web Exploitation](#web-exploitation)
-* [Android Utilities](#android-utilities)
 * [Windows Utilities](#windows-utilities)
-* [macOS Utilities](#macos-utilities)
+
+## Android Utilities
+
+* [Android Open Pwn Project (AOPP)](https://www.pwnieexpress.com/aopp) - Variant of the Android Open Source Project (AOSP), called Pwnix, is built from the ground up for network hacking and pentesting.
+* [cSploit](https://www.csploit.org/) - Advanced IT security professional toolkit on Android featuring an integrated Metasploit daemon and MITM capabilities.
+* [Fing](https://www.fing.com/products/fing-app/) - Network scanning and host enumeration app that performs NetBIOS, UPnP, Bonjour, SNMP, and various other advanced device fingerprinting techniques.
 
 ## Anonymity Tools
 
 * [I2P](https://geti2p.net/) - The Invisible Internet Project.
 * [Metadata Anonymization Toolkit (MAT)](https://0xacab.org/jvoisin/mat2) - Metadata removal tool, supporting a wide range of commonly used file formats, written in Python3.
+* [What Every Browser Knows About You](http://webkay.robinlinus.com/) - Comprehensive detection page to test your own Web browser's configuration for privacy and identity leaks.
+
+### Tor Tools
+
+See also [awesome-tor](https://github.com/ajvb/awesome-tor).
+
 * [Nipe](https://github.com/GouveaHeitor/nipe) - Script to redirect all traffic from the machine to the Tor network.
 * [OnionScan](https://onionscan.org/) - Tool for investigating the Dark Web by finding operational security issues introduced by Tor hidden service operators.
 * [Tails](https://tails.boum.org/) - Live operating system aiming to preserve your privacy and anonymity.
 * [Tor](https://www.torproject.org/) - Free software and onion routed overlay network that helps you defend against traffic analysis.
-* [What Every Browser Knows About You](http://webkay.robinlinus.com/) - Comprehensive detection page to test your own Web browser's configuration for privacy and identity leaks.
 * [dos-over-tor](https://github.com/skizap/dos-over-tor) - Proof of concept denial of service over Tor stress test tool.
 * [kalitorify](https://github.com/brainfuckSec/kalitorify) - Transparent proxy through Tor for Kali Linux OS.
 
@@ -166,14 +180,14 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [Unauthorised Access: Physical Penetration Testing For IT Security Teams by Wil Allsopp, 2010](http://www.amazon.com/Unauthorised-Access-Physical-Penetration-Security-ebook/dp/B005DIAPKE)
 * [Violent Python by TJ O'Connor, 2012](https://www.elsevier.com/books/violent-python/unknown/978-1-59749-957-6)
 
-### Privilege Escalation Tools
+## Privilege Escalation Tools
 
 * [Active Directory and Privilege Escalation (ADAPE)](https://github.com/hausec/ADAPE-Script) - Umbrella script that automates numerous useful PowerShell modules to discover security misconfigurations and attempt privilege escalation against Active Directory.
 * [LinEnum](https://github.com/rebootuser/LinEnum) - Scripted local Linux enumeration and privilege escalation checker useful for auditing a host and during CTF gaming.
 * [Postenum](https://github.com/mbahadou/postenum) - Shell script used for enumerating possible privilege escalation opportunities on a local GNU/Linux system.
 * [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
 
-### Reverse Engineering Books
+## Reverse Engineering Books
 
 * [Gray Hat Hacking The Ethical Hacker's Handbook by Daniel Regalado et al., 2015](http://www.amazon.com/Hacking-Ethical-Hackers-Handbook-Edition/dp/0071832386)
 * [Hacking the Xbox by Andrew Huang, 2003](https://nostarch.com/xbox.htm)
@@ -197,7 +211,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 ## CTF Tools
 
-* [Pwntools](https://github.com/Gallopsled/pwntools) - Rapid exploit development framework built for use in CTFs.
+* [CTF Field Guide](https://trailofbits.github.io/ctf/) - Everything you need to win your next CTF competition.
 * [RsaCtfTool](https://github.com/Ganapati/RsaCtfTool) - Decrypt data enciphered using weak RSA keys, and recover private keys from public keys using a variety of automated attacks.
 * [ctf-tools](https://github.com/zardus/ctf-tools) - Collection of setup scripts to install various security research tools easily and quickly deployable to new machines.
 * [shellpop](https://github.com/0x00-0x00/shellpop) - Easily generate sophisticated reverse or bind shell commands to help you save time during penetration tests.
@@ -212,6 +226,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 ## Conferences and Events
 
 * [BSides](http://www.securitybsides.com/) - Framework for organising and holding security conferences.
+* [CTFTime.org](https://ctftime.org/) - Directory of upcoming and archive of past Capture The Flag (CTF) competitions with links to challenge writeups.
 
 ### Asia
 
@@ -289,6 +304,23 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [Security Ninjas](https://hub.docker.com/r/opendns/security-ninjas/) - `docker pull opendns/security-ninjas`.
 * [docker-metasploit](https://hub.docker.com/r/phocean/msf/) - `docker pull phocean/msf`.
 
+## Exfiltration Tools
+
+* [DET](https://github.com/sensepost/DET) - Proof of concept to perform data exfiltration using either single or multiple channel(s) at the same time.
+* [Iodine](https://code.kryo.se/iodine/) - Tunnel IPv4 data through a DNS server; useful for exfiltration from networks where Internet access is firewalled, but DNS queries are allowed.
+* [TrevorC2](https://github.com/trustedsec/trevorc2) - Client/server tool for masking command and control and data exfiltration through a normally browsable website, not typical HTTP POST requests.
+* [dnscat2](https://github.com/iagox86/dnscat2) - Tool designed to create an encrypted command and control channel over the DNS protocol, which is an effective tunnel out of almost every network.
+* [pwnat](https://github.com/samyk/pwnat) - Punches holes in firewalls and NATs.
+* [tgcd](http://tgcd.sourceforge.net/) - Simple Unix network utility to extend the accessibility of TCP/IP based network services beyond firewalls.
+
+## Exploit Development Tools
+
+See also *[Reverse Engineering Tools](#reverse-engineering-tools)*.
+
+* [Pwntools](https://github.com/Gallopsled/pwntools) - Rapid exploit development framework built for use in CTFs.
+* [peda](https://github.com/longld/peda) - Python Exploit Development Assistance for GDB.
+* [Wordpress Exploit Framework](https://github.com/rastating/wordpress-exploit-framework) - Ruby framework for developing and using modules which aid in the penetration testing of WordPress powered websites and systems.
+
 ## File Format Analysis Tools
 
 * [ExifTool](https://www.sno.phy.queensu.ca/~phil/exiftool/) - Platform-independent Perl library plus a command-line application for reading, writing and editing meta information in a wide variety of files.
@@ -315,7 +347,6 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [JWT Cracker](https://github.com/lmammino/jwt-cracker) - Simple HS256 JSON Web Token (JWT) token brute force cracker.
 * [John the Ripper](http://www.openwall.com/john/) - Fast password cracker.
 * [Rar Crack](http://rarcrack.sourceforge.net) - RAR bruteforce cracker.
-* [StegCracker](https://github.com/Paradoxis/StegCracker) - Steganography brute-force utility to uncover hidden data inside files.
 
 ## Hex Editors
 
@@ -334,6 +365,11 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 * [Industrial Exploitation Framework (ISF)](https://github.com/dark-lbp/isf) - Metasploit-like exploit framework based on routersploit designed to target Industrial Control Systems (ICS), SCADA devices, PLC firmware, and more.
 * [s7scan](https://github.com/klsecservices/s7scan) - Scanner for enumerating Siemens S7 PLCs on a TCP/IP or LLC network.
+
+## macOS Utilities
+
+* [Bella](https://github.com/kdaoudieh/Bella) - Pure Python post-exploitation data mining and remote administration tool for macOS.
+* [EvilOSX](https://github.com/Marten4n6/EvilOSX) - Modular RAT that uses numerous evasion and exfiltration techniques out-of-the-box.
 
 ## Multi-paradigm Frameworks
 
@@ -376,16 +412,6 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [T50](https://gitlab.com/fredericopissarra/t50/) - Faster network stress tool.
 * [UFONet](https://github.com/epsylon/ufonet) - Abuses OSI layer 7 HTTP to create/manage 'zombies' and to conduct different attacks using; `GET`/`POST`, multithreading, proxies, origin spoofing methods, cache evasion techniques, etc.
 
-### Exfiltration Tools
-
-* [Cloakify](https://github.com/TryCatchHCF/Cloakify) - Textual steganography toolkit that converts any filetype into lists of everyday strings.
-* [DET](https://github.com/sensepost/DET) - Proof of concept to perform data exfiltration using either single or multiple channel(s) at the same time.
-* [Iodine](https://code.kryo.se/iodine/) - Tunnel IPv4 data through a DNS server; useful for exfiltration from networks where Internet access is firewalled, but DNS queries are allowed.
-* [TrevorC2](https://github.com/trustedsec/trevorc2) - Client/server tool for masking command and control and data exfiltration through a normally browsable website, not typical HTTP POST requests.
-* [dnscat2](https://github.com/iagox86/dnscat2) - Tool designed to create an encrypted command and control channel over the DNS protocol, which is an effective tunnel out of almost every network.
-* [pwnat](https://github.com/samyk/pwnat) - Punches holes in firewalls and NATs.
-* [tgcd](http://tgcd.sourceforge.net/) - Simple Unix network utility to extend the accessibility of TCP/IP based network services beyond firewalls.
-
 ### Network Reconnaissance Tools
 
 * [ACLight](https://github.com/cyberark/ACLight) - Script for advanced discovery of sensitive Privileged Accounts - includes Shadow Admins.
@@ -411,6 +437,8 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [zmap](https://zmap.io/) - Open source network scanner that enables researchers to easily perform Internet-wide network studies.
 
 ### Protocol Analyzers and Sniffers
+
+See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 
 * [Debookee](http://www.iwaxx.com/debookee/) - Simple and powerful network traffic analyzer for macOS.
 * [Dshell](https://github.com/USArmyResearchLab/Dshell) - Network forensic analysis framework.
@@ -595,7 +623,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Penetration Testing Framework (PTF)](http://www.vulnerabilityassessment.co.uk/Penetration%20Test.html) - Outline for performing penetration tests compiled as a general framework usable by vulnerability analysts and penetration testers alike.
 * [XSS-Payloads](http://www.xss-payloads.com) - Resource dedicated to all things XSS (cross-site), including payloads, tools, games, and documentation.
 
-### Social Engineering Resources
+### Online Social Engineering Resources
 
 * [Social Engineering Framework](http://www.social-engineer.org/framework/general-discussion/) - Information resource for social engineers.
 
@@ -610,7 +638,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Awesome Lockpicking](https://github.com/meitar/awesome-lockpicking) - Awesome guides, tools, and other resources about the security and compromise of locks, safes, and keys.
 * [Awesome Shodan Queries](https://github.com/jakejarvis/awesome-shodan-queries) - Awesome list of useful, funny, and depressing search queries for Shodan.
 * [AWS Tool Arsenal](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of tools for testing and securing AWS environments.
-* [Blue Team](https://github.com/meitar/awesome-cybersecurity-blueteam) - Awesome resources, tools, and other shiny things for cybersecurity blue teams.
+* [Blue Team](https://github.com/fabacab/awesome-cybersecurity-blueteam) - Awesome resources, tools, and other shiny things for cybersecurity blue teams.
 * [C/C++ Programming](https://github.com/fffaraz/awesome-cpp) - One of the main language for open source security tools.
 * [CTFs](https://github.com/apsdehal/awesome-ctf) - Capture The Flag frameworks, libraries, etc.
 * [Forensics](https://github.com/Cugu/awesome-forensics) - Free (mostly open source) forensic analysis tools and resources.
@@ -624,7 +652,6 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Malware Analysis](https://github.com/rshipp/awesome-malware-analysis) - Tools and resources for analysts.
 * [Node.js Programming by @sindresorhus](https://github.com/sindresorhus/awesome-nodejs) - Curated list of delightful Node.js packages and resources.
 * [OSINT](https://github.com/jivoi/awesome-osint) - Awesome OSINT list containing great resources.
-* [PCAP Tools](https://github.com/caesar0301/awesome-pcaptools) - Tools for processing network traffic.
 * [Pentest Cheat Sheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets) - Awesome Pentest Cheat Sheets.
 * [Python Programming by @svaksha](https://github.com/svaksha/pythonidae) - General Python programming.
 * [Python Programming by @vinta](https://github.com/vinta/awesome-python) - General Python programming.
@@ -700,7 +727,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [binwalk](https://github.com/devttys0/binwalk) - Fast, easy to use tool for analyzing, reverse engineering, and extracting firmware images.
 * [boxxy](https://github.com/kpcyrd/boxxy-rs) - Linkable sandbox explorer.
 * [dnSpy](https://github.com/0xd4d/dnSpy) - Tool to reverse engineer .NET assemblies.
-* [peda](https://github.com/longld/peda) - Python Exploit Development Assistance for GDB.
 * [plasma](https://github.com/joelpx/plasma) - Interactive disassembler for x86/ARM/MIPS. Generates indented pseudo-code with colored syntax code.
 * [pwndbg](https://github.com/pwndbg/pwndbg) - GDB plug-in that eases debugging with GDB, with a focus on features needed by low-level software developers, hardware hackers, reverse-engineers, and exploit developers.
 * [rVMI](https://github.com/fireeye/rVMI) - Debugger on steroids; inspect userspace processes, kernel drivers, and preboot environments in a single tool.
@@ -709,7 +735,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 ## Security Education Courses
 
 * [ARIZONA CYBER WARFARE RANGE](http://azcwr.org/) - 24x7 live fire exercises for beginners through real world operations; capability for upward progression into the real world of cyber warfare.
-* [CTF Field Guide](https://trailofbits.github.io/ctf/) - Everything you need to win your next CTF competition.
 * [Cybrary](http://cybrary.it) - Free courses in ethical hacking and advanced penetration testing. Advanced penetration testing courses are based on the book 'Penetration Testing for Highly Secured Environments'.
 * [European Union Agency for Network and Information Security](https://www.enisa.europa.eu/topics/trainings-for-cybersecurity-specialists/online-training-material) - ENISA Cyber Security Training material.
 * [Offensive Security Training](https://www.offensive-security.com/information-security-training/) - Training from BackTrack/Kali developers.
@@ -748,6 +773,11 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [cppcheck](http://cppcheck.sourceforge.net/) - Extensible C/C++ static analyzer focused on finding bugs.
 * [sobelow](https://github.com/nccgroup/sobelow) - Security-focused static analysis for the Phoenix Framework.
 * [cwe_checker](https://github.com/fkie-cad/cwe_checker) - Suite of tools built atop the Binary Analysis Platform (BAP) to heuristically detect CWEs in compiled binaries and firmware.
+
+## Steganography Tools
+
+* [Cloakify](https://github.com/TryCatchHCF/Cloakify) - Textual steganography toolkit that converts any filetype into lists of everyday strings.
+* [StegCracker](https://github.com/Paradoxis/StegCracker) - Steganography brute-force utility to uncover hidden data inside files.
 
 ## Vulnerability Databases
 
@@ -796,7 +826,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [Wappalyzer](https://www.wappalyzer.com/) - Wappalyzer uncovers the technologies used on websites.
 * [WhatWaf](https://github.com/Ekultek/WhatWaf) - Detect and bypass web application firewalls and protection systems.
 * [WhatWeb](https://github.com/urbanadventurer/WhatWeb) - Website fingerprinter.
-* [Wordpress Exploit Framework](https://github.com/rastating/wordpress-exploit-framework) - Ruby framework for developing and using modules which aid in the penetration testing of WordPress powered websites and systems.
 * [autochrome](https://www.nccgroup.trust/us/about-us/newsroom-and-events/blog/2017/march/autochrome/) - Easy to install a test browser with all the appropriate setting needed for web application testing with native Burp support, from NCCGroup.
 * [badtouch](https://github.com/kpcyrd/badtouch) - Scriptable network authentication cracker.
 * [fimap](https://github.com/kurobeats/fimap) - Find, prepare, audit, exploit and even Google automatically for LFI/RFI bugs.
@@ -808,12 +837,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [wafw00f](https://github.com/EnableSecurity/wafw00f) - Identifies and fingerprints Web Application Firewall (WAF) products.
 * [webscreenshot](https://github.com/maaaaz/webscreenshot) - Simple script to take screenshots of websites from a list of sites.
 * [weevely3](https://github.com/epinna/weevely3) - Weaponized PHP-based web shell.
-
-## Android Utilities
-
-* [Android Open Pwn Project (AOPP)](https://www.pwnieexpress.com/aopp) - Variant of the Android Open Source Project (AOSP), called Pwnix, is built from the ground up for network hacking and pentesting.
-* [cSploit](https://www.csploit.org/) - Advanced IT security professional toolkit on Android featuring an integrated Metasploit daemon and MITM capabilities.
-* [Fing](https://www.fing.com/products/fing-app/) - Network scanning and host enumeration app that performs NetBIOS, UPnP, Bonjour, SNMP, and various other advanced device fingerprinting techniques.
 
 ## Windows Utilities
 
@@ -841,11 +864,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [redsnarf](https://github.com/nccgroup/redsnarf) - Post-exploitation tool for retrieving password hashes and credentials from Windows workstations, servers, and domain controllers.
 * [wePWNise](https://labs.mwrinfosecurity.com/tools/wepwnise/) - Generates architecture independent VBA code to be used in Office documents or templates and automates bypassing application control and exploit mitigation software.
 * [WinPwn](https://github.com/SecureThisShit/WinPwn) - Internal penetration test script to perform local and domain reconnaissance, privilege escalation and exploitation.
-
-## macOS Utilities
-
-* [Bella](https://github.com/kdaoudieh/Bella) - Pure Python post-exploitation data mining and remote administration tool for macOS.
-* [EvilOSX](https://github.com/Marten4n6/EvilOSX) - Modular RAT that uses numerous evasion and exfiltration techniques out-of-the-box.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -51,22 +51,24 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Wireless Network Tools](#wireless-network-tools)
 * [Network Vulnerability Scanners](#network-vulnerability-scanners)
   * [Web Vulnerability Scanners](#web-vulnerability-scanners)
-* [OSINT Tools](#osint-tools)
+* [Open Sources Intelligence (OSINT)](#open-sources-intelligence-osint)
   * [Data broker and search engine services](#data-broker-and-search-engine-services)
   * [Dorking tools](#dorking-tools)
   * [Email search and analysis tools](#email-search-and-analysis-tools)
   * [Metadata harvesting and analysis](#metadata-harvesting-and-analysis)
   * [Network device discovery tools](#network-device-discovery-tools)
   * [Source code repository searching tools](#source-code-repository-searching-tools)
+  * [OSINT Online Resources](#osint-online-resources)
+  * [OSINT Tools](#osint-tools)
 * [Online Resources](#online-resources)
   * [Online Code Samples and Examples](#online-code-samples-and-examples)
   * [Online Exploit Development Resources](#online-exploit-development-resources)
   * [Online Lock Picking Resources](#online-lock-picking-resources)
-  * [Online Open Sources Intelligence (OSINT) Resources](#online-open-sources-intelligence-osint-resources)
   * [Online Operating Systems Resources](#online-operating-systems-resources)
   * [Online Penetration Testing Resources](#online-penetration-testing-resources)
   * [Other Lists Online](#other-lists-online)
   * [Penetration Testing Report Templates](#penetration-testing-report-templates)
+* [Open Sources Intelligence (OSINT)](#open-sources-intelligence-osint)
 * [Operating System Distributions](#operating-system-distributions)
 * [Periodicals](#periodicals)
 * [Physical Access Tools](#physical-access-tools)
@@ -491,23 +493,83 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [joomscan](https://www.owasp.org/index.php/Category:OWASP_Joomla_Vulnerability_Scanner_Project) - Joomla vulnerability scanner.
 * [w3af](https://github.com/andresriancho/w3af) - Web application attack and audit framework.
 
-## OSINT Tools
+## Online Resources
 
-* [DataSploit](https://github.com/upgoingstar/datasploit) - OSINT visualizer utilizing Shodan, Censys, Clearbit, EmailHunter, FullContact, and Zoomeye behind the scenes.
-* [GyoiThon](https://github.com/gyoisamurai/GyoiThon) - GyoiThon is an Intelligence Gathering tool using Machine Learning.
-* [Intrigue](http://intrigue.io) - Automated OSINT & Attack Surface discovery framework with powerful API, UI and CLI.
-* [Maltego](http://www.maltego.com/) - Proprietary software for open sources intelligence and forensics.
-* [PacketTotal](https://packettotal.com/) - Simple, free, high-quality packet capture file analysis facilitating the quick detection of network-borne malware (using Bro and Suricata IDS signatures under the hood).
-* [Skiptracer](https://github.com/xillwillx/skiptracer) - OSINT scraping framework that utilizes basic Python webscraping (BeautifulSoup) of PII paywall sites to compile passive information on a target on a ramen noodle budget.
-* [Sn1per](https://github.com/1N3/Sn1per) - Automated Pentest Recon Scanner.
-* [Spiderfoot](http://www.spiderfoot.net/) - Multi-source OSINT automation tool with a Web UI and report visualizations.
-* [creepy](https://github.com/ilektrojohn/creepy) - Geolocation OSINT tool.
-* [gOSINT](https://github.com/Nhoya/gOSINT) - OSINT tool with multiple modules and a telegram scraper.
-* [image-match](https://github.com/ascribe/image-match) - Quickly search over billions of images.
-* [recon-ng](https://github.com/lanmaster53/recon-ng) - Full-featured Web Reconnaissance framework written in Python.
-* [sn0int](https://github.com/kpcyrd/sn0int) - Semi-automatic OSINT framework and package manager.
+### Online Code Samples and Examples
 
-### Data broker and search engine services
+* [goHackTools](https://github.com/dreddsa5dies/goHackTools) - Hacker tools on Go (Golang).
+
+### Online Exploit Development Resources
+
+* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to develop exploits.
+* [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database.
+* [Shellcode Tutorial](http://www.vividmachines.com/shellcode/shellcode.html) - Tutorial on how to write shellcode.
+
+### Online Operating Systems Resources
+
+* [DistroWatch.com's Security Category](https://distrowatch.com/search.php?category=Security) - Website dedicated to talking about, reviewing, and keeping up to date with open source operating systems.
+
+### Online Penetration Testing Resources
+
+* [InfoSec Institute](https://resources.infosecinstitute.com) - IT and security articles.
+* [MITRE's Adversarial Tactics, Techniques & Common Knowledge (ATT&CK)](https://attack.mitre.org/) - Curated knowledge base and model for cyber adversary behavior.
+* [Metasploit Unleashed](https://www.offensive-security.com/metasploit-unleashed/) - Free Offensive Security Metasploit course.
+* [Open Web Application Security Project (OWASP)](https://www.owasp.org/index.php/Main_Page) - Worldwide not-for-profit charitable organization focused on improving the security of especially Web-based and Application-layer software.
+* [PENTEST-WIKI](https://github.com/nixawk/pentest-wiki) - Free online security knowledge library for pentesters and researchers.
+* [Penetration Testing Execution Standard (PTES)](http://www.pentest-standard.org/) - Documentation designed to provide a common language and scope for performing and reporting the results of a penetration test.
+* [Penetration Testing Framework (PTF)](http://www.vulnerabilityassessment.co.uk/Penetration%20Test.html) - Outline for performing penetration tests compiled as a general framework usable by vulnerability analysts and penetration testers alike.
+* [XSS-Payloads](http://www.xss-payloads.com) - Resource dedicated to all things XSS (cross-site), including payloads, tools, games, and documentation.
+
+### Other Lists Online
+
+* [.NET Programming](https://github.com/quozd/awesome-dotnet) - Software framework for Microsoft Windows platform development.
+* [Infosec/hacking videos recorded by cooper](https://administraitor.video) - Collection of security conferences recorded by Cooper.
+* [Android Exploits](https://github.com/sundaysec/Android-Exploits) - Guide on Android Exploitation and Hacks.
+* [Android Security](https://github.com/ashishb/android-security-awesome) - Collection of Android security related resources.
+* [AppSec](https://github.com/paragonie/awesome-appsec) - Resources for learning about application security.
+* [Awesome Awesomness](https://github.com/bayandin/awesome-awesomeness) - The List of the Lists.
+* [Awesome Shodan Queries](https://github.com/jakejarvis/awesome-shodan-queries) - Awesome list of useful, funny, and depressing search queries for Shodan.
+* [AWS Tool Arsenal](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of tools for testing and securing AWS environments.
+* [Blue Team](https://github.com/fabacab/awesome-cybersecurity-blueteam) - Awesome resources, tools, and other shiny things for cybersecurity blue teams.
+* [C/C++ Programming](https://github.com/fffaraz/awesome-cpp) - One of the main language for open source security tools.
+* [CTFs](https://github.com/apsdehal/awesome-ctf) - Capture The Flag frameworks, libraries, etc.
+* [Forensics](https://github.com/Cugu/awesome-forensics) - Free (mostly open source) forensic analysis tools and resources.
+* [Hacking](https://github.com/carpedm20/awesome-hacking) - Tutorials, tools, and resources.
+* [Honeypots](https://github.com/paralax/awesome-honeypots) - Honeypots, tools, components, and more.
+* [InfoSec § Hacking challenges](https://github.com/AnarchoTechNYC/meta/wiki/InfoSec#hacking-challenges) - Comprehensive directory of CTFs, wargames, hacking challenge websites, pentest practice lab exercises, and more.
+* [Infosec](https://github.com/onlurking/awesome-infosec) - Information security resources for pentesting, forensics, and more.
+* [Security-related Operating Systems](https://list.rawsec.ml/operating_systems.html) - List of security related operating systems.
+* [JavaScript Programming](https://github.com/sorrycc/awesome-javascript) - In-browser development and scripting.
+* [Kali Linux Tools](http://tools.kali.org/tools-listing) - List of tools present in Kali Linux.
+* [Malware Analysis](https://github.com/rshipp/awesome-malware-analysis) - Tools and resources for analysts.
+* [Node.js Programming by @sindresorhus](https://github.com/sindresorhus/awesome-nodejs) - Curated list of delightful Node.js packages and resources.
+* [Pentest Cheat Sheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets) - Awesome Pentest Cheat Sheets.
+* [Python Programming by @svaksha](https://github.com/svaksha/pythonidae) - General Python programming.
+* [Python Programming by @vinta](https://github.com/vinta/awesome-python) - General Python programming.
+* [Python tools for penetration testers](https://github.com/dloss/python-pentest-tools) - Lots of pentesting tools are written in Python.
+* [Red Teaming](https://github.com/yeyintminthuhtut/Awesome-Red-Teaming) - List of Awesome Red Teaming Resources.
+* [Ruby Programming by @Sdogruyol](https://github.com/Sdogruyol/awesome-ruby) - The de-facto language for writing exploits.
+* [Ruby Programming by @dreikanter](https://github.com/dreikanter/ruby-bookmarks) - The de-facto language for writing exploits.
+* [Ruby Programming by @markets](https://github.com/markets/awesome-ruby) - The de-facto language for writing exploits.
+* [SecLists](https://github.com/danielmiessler/SecLists) - Collection of multiple types of lists used during security assessments.
+* [SecTools](http://sectools.org/) - Top 125 Network Security Tools.
+* [Security Talks](https://github.com/PaulSec/awesome-sec-talks) - Curated list of security conferences.
+* [Security](https://github.com/sbilly/awesome-security) - Software, libraries, documents, and other resources.
+* [Serverless Security](https://github.com/puresec/awesome-serverless-security/) - Curated list of awesome serverless security resources such as (e)books, articles, whitepapers, blogs and research papers.
+* [Shell Scripting](https://github.com/alebcay/awesome-shell) - Command line frameworks, toolkits, guides and gizmos.
+* [YARA](https://github.com/InQuest/awesome-yara) - YARA rules, tools, and people.
+
+### Penetration Testing Report Templates
+
+* [Public Pentesting Reports](https://github.com/juliocesarfort/public-pentesting-reports) - Curated list of public penetration test reports released by several consulting firms and academic security groups.
+* [T&VS Pentesting Report Template](https://www.testandverification.com/wp-content/uploads/template-penetration-testing-report-v03.pdf) - Pentest report template provided by Test and Verification Services, Ltd.
+* [Web Application Security Assessment Report Template](http://lucideus.com/pdf/stw.pdf) - Sample Web application security assessment reporting template provided by Lucideus.
+
+## Open Sources Intelligence (OSINT)
+
+See also [awesome-osint](https://github.com/jivoi/awesome-osint).
+
+### Data Broker and Search Engine Services
 
 * [Hunter.io](https://hunter.io/) - Data broker providing a Web search interface for discovering the email addresses and other organizational details of a company.
 * [Threat Crowd](https://www.threatcrowd.org/) - Search engine for threats.
@@ -549,19 +611,7 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [vcsmap](https://github.com/melvinsh/vcsmap) - Plugin-based tool to scan public version control systems for sensitive information.
 * [Yar](https://github.com/Furduhlutur/yar) - Clone git repositories to search through the whole commit history in order of commit time for secrets, tokens, or passwords.
 
-## Online Resources
-
-### Online Code Samples and Examples
-
-* [goHackTools](https://github.com/dreddsa5dies/goHackTools) - Hacker tools on Go (Golang).
-
-### Online Exploit Development Resources
-
-* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to develop exploits.
-* [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database.
-* [Shellcode Tutorial](http://www.vividmachines.com/shellcode/shellcode.html) - Tutorial on how to write shellcode.
-
-### Online Open Sources Intelligence (OSINT) Resources
+### OSINT Online Resources
 
 * [CertGraph](https://github.com/lanrat/certgraph) - Crawls a domain's SSL/TLS certificates for its certificate alternative names.
 * [GhostProject](https://ghostproject.fr/) - Searchable database of billions of cleartext passwords, partially visible for free.
@@ -569,66 +619,21 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [OSINT Framework](http://osintframework.com/) - Collection of various OSINT tools broken out by category.
 * [WiGLE.net](https://wigle.net/) - Information about wireless networks world-wide, with user-friendly desktop and web applications.
 
-### Online Operating Systems Resources
+### OSINT Tools
 
-* [DistroWatch.com's Security Category](https://distrowatch.com/search.php?category=Security) - Website dedicated to talking about, reviewing, and keeping up to date with open source operating systems.
-
-### Online Penetration Testing Resources
-
-* [InfoSec Institute](https://resources.infosecinstitute.com) - IT and security articles.
-* [MITRE's Adversarial Tactics, Techniques & Common Knowledge (ATT&CK)](https://attack.mitre.org/) - Curated knowledge base and model for cyber adversary behavior.
-* [Metasploit Unleashed](https://www.offensive-security.com/metasploit-unleashed/) - Free Offensive Security Metasploit course.
-* [Open Web Application Security Project (OWASP)](https://www.owasp.org/index.php/Main_Page) - Worldwide not-for-profit charitable organization focused on improving the security of especially Web-based and Application-layer software.
-* [PENTEST-WIKI](https://github.com/nixawk/pentest-wiki) - Free online security knowledge library for pentesters and researchers.
-* [Penetration Testing Execution Standard (PTES)](http://www.pentest-standard.org/) - Documentation designed to provide a common language and scope for performing and reporting the results of a penetration test.
-* [Penetration Testing Framework (PTF)](http://www.vulnerabilityassessment.co.uk/Penetration%20Test.html) - Outline for performing penetration tests compiled as a general framework usable by vulnerability analysts and penetration testers alike.
-* [XSS-Payloads](http://www.xss-payloads.com) - Resource dedicated to all things XSS (cross-site), including payloads, tools, games, and documentation.
-
-### Other Lists Online
-
-* [.NET Programming](https://github.com/quozd/awesome-dotnet) - Software framework for Microsoft Windows platform development.
-* [Infosec/hacking videos recorded by cooper](https://administraitor.video) - Collection of security conferences recorded by Cooper.
-* [Android Exploits](https://github.com/sundaysec/Android-Exploits) - Guide on Android Exploitation and Hacks.
-* [Android Security](https://github.com/ashishb/android-security-awesome) - Collection of Android security related resources.
-* [AppSec](https://github.com/paragonie/awesome-appsec) - Resources for learning about application security.
-* [Awesome Awesomness](https://github.com/bayandin/awesome-awesomeness) - The List of the Lists.
-* [Awesome Shodan Queries](https://github.com/jakejarvis/awesome-shodan-queries) - Awesome list of useful, funny, and depressing search queries for Shodan.
-* [AWS Tool Arsenal](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of tools for testing and securing AWS environments.
-* [Blue Team](https://github.com/fabacab/awesome-cybersecurity-blueteam) - Awesome resources, tools, and other shiny things for cybersecurity blue teams.
-* [C/C++ Programming](https://github.com/fffaraz/awesome-cpp) - One of the main language for open source security tools.
-* [CTFs](https://github.com/apsdehal/awesome-ctf) - Capture The Flag frameworks, libraries, etc.
-* [Forensics](https://github.com/Cugu/awesome-forensics) - Free (mostly open source) forensic analysis tools and resources.
-* [Hacking](https://github.com/carpedm20/awesome-hacking) - Tutorials, tools, and resources.
-* [Honeypots](https://github.com/paralax/awesome-honeypots) - Honeypots, tools, components, and more.
-* [InfoSec § Hacking challenges](https://github.com/AnarchoTechNYC/meta/wiki/InfoSec#hacking-challenges) - Comprehensive directory of CTFs, wargames, hacking challenge websites, pentest practice lab exercises, and more.
-* [Infosec](https://github.com/onlurking/awesome-infosec) - Information security resources for pentesting, forensics, and more.
-* [Security-related Operating Systems](https://list.rawsec.ml/operating_systems.html) - List of security related operating systems.
-* [JavaScript Programming](https://github.com/sorrycc/awesome-javascript) - In-browser development and scripting.
-* [Kali Linux Tools](http://tools.kali.org/tools-listing) - List of tools present in Kali Linux.
-* [Malware Analysis](https://github.com/rshipp/awesome-malware-analysis) - Tools and resources for analysts.
-* [Node.js Programming by @sindresorhus](https://github.com/sindresorhus/awesome-nodejs) - Curated list of delightful Node.js packages and resources.
-* [OSINT](https://github.com/jivoi/awesome-osint) - Awesome OSINT list containing great resources.
-* [Pentest Cheat Sheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets) - Awesome Pentest Cheat Sheets.
-* [Python Programming by @svaksha](https://github.com/svaksha/pythonidae) - General Python programming.
-* [Python Programming by @vinta](https://github.com/vinta/awesome-python) - General Python programming.
-* [Python tools for penetration testers](https://github.com/dloss/python-pentest-tools) - Lots of pentesting tools are written in Python.
-* [Red Teaming](https://github.com/yeyintminthuhtut/Awesome-Red-Teaming) - List of Awesome Red Teaming Resources.
-* [Ruby Programming by @Sdogruyol](https://github.com/Sdogruyol/awesome-ruby) - The de-facto language for writing exploits.
-* [Ruby Programming by @dreikanter](https://github.com/dreikanter/ruby-bookmarks) - The de-facto language for writing exploits.
-* [Ruby Programming by @markets](https://github.com/markets/awesome-ruby) - The de-facto language for writing exploits.
-* [SecLists](https://github.com/danielmiessler/SecLists) - Collection of multiple types of lists used during security assessments.
-* [SecTools](http://sectools.org/) - Top 125 Network Security Tools.
-* [Security Talks](https://github.com/PaulSec/awesome-sec-talks) - Curated list of security conferences.
-* [Security](https://github.com/sbilly/awesome-security) - Software, libraries, documents, and other resources.
-* [Serverless Security](https://github.com/puresec/awesome-serverless-security/) - Curated list of awesome serverless security resources such as (e)books, articles, whitepapers, blogs and research papers.
-* [Shell Scripting](https://github.com/alebcay/awesome-shell) - Command line frameworks, toolkits, guides and gizmos.
-* [YARA](https://github.com/InQuest/awesome-yara) - YARA rules, tools, and people.
-
-### Penetration Testing Report Templates
-
-* [Public Pentesting Reports](https://github.com/juliocesarfort/public-pentesting-reports) - Curated list of public penetration test reports released by several consulting firms and academic security groups.
-* [T&VS Pentesting Report Template](https://www.testandverification.com/wp-content/uploads/template-penetration-testing-report-v03.pdf) - Pentest report template provided by Test and Verification Services, Ltd.
-* [Web Application Security Assessment Report Template](http://lucideus.com/pdf/stw.pdf) - Sample Web application security assessment reporting template provided by Lucideus.
+* [DataSploit](https://github.com/upgoingstar/datasploit) - OSINT visualizer utilizing Shodan, Censys, Clearbit, EmailHunter, FullContact, and Zoomeye behind the scenes.
+* [GyoiThon](https://github.com/gyoisamurai/GyoiThon) - GyoiThon is an Intelligence Gathering tool using Machine Learning.
+* [Intrigue](http://intrigue.io) - Automated OSINT & Attack Surface discovery framework with powerful API, UI and CLI.
+* [Maltego](http://www.maltego.com/) - Proprietary software for open sources intelligence and forensics.
+* [PacketTotal](https://packettotal.com/) - Simple, free, high-quality packet capture file analysis facilitating the quick detection of network-borne malware (using Bro and Suricata IDS signatures under the hood).
+* [Skiptracer](https://github.com/xillwillx/skiptracer) - OSINT scraping framework that utilizes basic Python webscraping (BeautifulSoup) of PII paywall sites to compile passive information on a target on a ramen noodle budget.
+* [Sn1per](https://github.com/1N3/Sn1per) - Automated Pentest Recon Scanner.
+* [Spiderfoot](http://www.spiderfoot.net/) - Multi-source OSINT automation tool with a Web UI and report visualizations.
+* [creepy](https://github.com/ilektrojohn/creepy) - Geolocation OSINT tool.
+* [gOSINT](https://github.com/Nhoya/gOSINT) - OSINT tool with multiple modules and a telegram scraper.
+* [image-match](https://github.com/ascribe/image-match) - Quickly search over billions of images.
+* [recon-ng](https://github.com/lanmaster53/recon-ng) - Full-featured Web Reconnaissance framework written in Python.
+* [sn0int](https://github.com/kpcyrd/sn0int) - Semi-automatic OSINT framework and package manager.
 
 ## Operating System Distributions
 

--- a/README.md
+++ b/README.md
@@ -496,7 +496,7 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [DataSploit](https://github.com/upgoingstar/datasploit) - OSINT visualizer utilizing Shodan, Censys, Clearbit, EmailHunter, FullContact, and Zoomeye behind the scenes.
 * [GyoiThon](https://github.com/gyoisamurai/GyoiThon) - GyoiThon is an Intelligence Gathering tool using Machine Learning.
 * [Intrigue](http://intrigue.io) - Automated OSINT & Attack Surface discovery framework with powerful API, UI and CLI.
-* [Maltego](http://www.paterva.com/web7/) - Proprietary software for open source intelligence and forensics, from Paterva.
+* [Maltego](http://www.maltego.com/) - Proprietary software for open sources intelligence and forensics.
 * [PacketTotal](https://packettotal.com/) - Simple, free, high-quality packet capture file analysis facilitating the quick detection of network-borne malware (using Bro and Suricata IDS signatures under the hood).
 * [Skiptracer](https://github.com/xillwillx/skiptracer) - OSINT scraping framework that utilizes basic Python webscraping (BeautifulSoup) of PII paywall sites to compile passive information on a target on a ramen noodle budget.
 * [Sn1per](https://github.com/1N3/Sn1per) - Automated Pentest Recon Scanner.

--- a/README.md
+++ b/README.md
@@ -747,7 +747,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing), [*
 * [King Phisher](https://github.com/securestate/king-phisher) - Phishing campaign toolkit used for creating and managing multiple simultaneous phishing attacks with custom email and server content.
 * [Modlishka](https://github.com/drk1wi/Modlishka) - Flexible and powerful reverse proxy with real-time two-factor authentication.
 * [ReelPhish](https://github.com/fireeye/ReelPhish) - Real-time two-factor phishing tool.
-* [ShellPhish](https://github.com/suljot/shellphish) - Social media site cloner and phishing tool built atop SocialFish.
 * [Social Engineer Toolkit (SET)](https://github.com/trustedsec/social-engineer-toolkit) - Open source pentesting framework designed for social engineering featuring a number of custom attack vectors to make believable attacks quickly.
 * [SocialFish](https://github.com/UndeadSec/SocialFish) - Social media phishing framework that can run on an Android phone or in a Docker container.
 * [phishery](https://github.com/ryhanson/phishery) - TLS/SSL enabled Basic Auth credential harvester.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Malware Analysis Books](#malware-analysis-books)
   * [Network Analysis Books](#network-analysis-books)
   * [Penetration Testing Books](#penetration-testing-books)
-  * [Social Engineering Books](#social-engineering-books)
   * [Windows Books](#windows-books)
 * [CTF Tools](#ctf-tools)
 * [Collaboration Tools](#collaboration-tools)
@@ -30,9 +29,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [North America](#north-america)
   * [South America](#south-america)
   * [Zealandia](#zealandia)
-* [Docker Containers](#docker-containers)
-  * [Docker Containers of Intentionally Vulnerable Systems](#docker-containers-of-intentionally-vulnerable-systems)
-  * [Docker Containers of Penetration Testing Distributions and Tools](#docker-containers-of-penetration-testing-distributions-and-tools)
 * [Exfiltration Tools](#exfiltration-tools)
 * [Exploit Development Tools](#exploit-development-tools)
 * [File Format Analysis Tools](#file-format-analysis-tools)
@@ -40,6 +36,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Hash Cracking Tools](#hash-cracking-tools)
 * [Hex Editors](#hex-editors)
 * [Industrial Control and SCADA Systems](#industrial-control-and-scada-systems)
+* [Intentionally Vulnerable Systems](#intentionally-vulnerable-systems)
+  * [Intentionally Vulnerable Systems as Docker Containers](#intentionally-vulnerable-systems-as-docker-containers)
 * [Lock Picking](#lock-picking)
 * [macOS Utilities](#macos-utilities)
 * [Multi-paradigm Frameworks](#multi-paradigm-frameworks)
@@ -67,7 +65,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Online Open Sources Intelligence (OSINT) Resources](#online-open-sources-intelligence-osint-resources)
   * [Online Operating Systems Resources](#online-operating-systems-resources)
   * [Online Penetration Testing Resources](#online-penetration-testing-resources)
-  * [Online Social Engineering Resources](#online-social-engineering-resources)
   * [Other Lists Online](#other-lists-online)
   * [Penetration Testing Report Templates](#penetration-testing-report-templates)
 * [Operating System Distributions](#operating-system-distributions)
@@ -79,11 +76,15 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Reverse Engineering Tools](#reverse-engineering-tools)
 * [Security Education Courses](#security-education-courses)
 * [Side-channel Tools](#side-channel-tools)
-* [Social Engineering Tools](#social-engineering-tools)
+* [Social Engineering](#social-engineering)
+  * [Social Engineering Books](#social-engineering-books)
+  * [Social Engineering Online Resources](#social-engineering-online-resources)
+  * [Social Engineering Tools](#social-engineering-tools)
 * [Static Analyzers](#static-analyzers)
 * [Steganography Tools](#steganography-tools)
 * [Vulnerability Databases](#vulnerability-databases)
 * [Web Exploitation](#web-exploitation)
+  * [Web Exploitation Books](#web-exploitation-books)
 * [Windows Utilities](#windows-utilities)
 
 ## Android Utilities
@@ -133,12 +134,10 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 * [Android Hacker's Handbook by Joshua J. Drake et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-111860864X.html)
 * [Car Hacker's Handbook by Craig Smith, 2016](https://nostarch.com/carhacking)
-* [The Browser Hacker's Handbook by Wade Alcorn et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118662091.html)
 * [The Database Hacker's Handbook, David Litchfield et al., 2005](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0764578014.html)
 * [The Mac Hacker's Handbook by Charlie Miller & Dino Dai Zovi, 2009](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470395362.html)
 * [The Mobile Application Hacker's Handbook by Dominic Chell et al., 2015](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118958500.html)
 * [The Shellcoder's Handbook by Chris Anley et al., 2007](http://www.wiley.com/WileyCDA/WileyTitle/productCd-047008023X.html)
-* [The Web Application Hacker's Handbook by D. Stuttard, M. Pinto, 2011](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118026470.html)
 * [iOS Hacker's Handbook by Charlie Miller et al., 2012](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118204123.html)
 
 ### Malware Analysis Books
@@ -173,15 +172,6 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [The Hacker Playbook by Peter Kim, 2014](http://www.amazon.com/The-Hacker-Playbook-Practical-Penetration/dp/1494932636/)
 * [Unauthorised Access: Physical Penetration Testing For IT Security Teams by Wil Allsopp, 2010](http://www.amazon.com/Unauthorised-Access-Physical-Penetration-Security-ebook/dp/B005DIAPKE)
 * [Violent Python by TJ O'Connor, 2012](https://www.elsevier.com/books/violent-python/unknown/978-1-59749-957-6)
-
-### Social Engineering Books
-
-* [Ghost in the Wires by Kevin D. Mitnick & William L. Simon, 2011](http://www.hachettebookgroup.com/titles/kevin-mitnick/ghost-in-the-wires/9780316134477/)
-* [No Tech Hacking by Johnny Long & Jack Wiles, 2008](https://www.elsevier.com/books/no-tech-hacking/mitnick/978-1-59749-215-7)
-* [Social Engineering in IT Security: Tools, Tactics, and Techniques by Sharon Conheady, 2014](https://www.mhprofessional.com/9780071818469-usa-social-engineering-in-it-security-tools-tactics-and-techniques-group)
-* [The Art of Deception by Kevin D. Mitnick & William L. Simon, 2002](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0471237124.html)
-* [The Art of Intrusion by Kevin D. Mitnick & William L. Simon, 2005](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0764569597.html)
-* [Unmasking the Social Engineer: The Human Element of Security by Christopher Hadnagy, 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118608577.html)
 
 ### Windows Books
 
@@ -258,31 +248,6 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 * [CHCon](https://chcon.nz) - Christchurch Hacker Con, Only South Island of New Zealand hacker con.
 
-## Docker Containers
-
-### Docker Containers of Intentionally Vulnerable Systems
-
-* [Damn Vulnerable Web Application (DVWA)](https://hub.docker.com/r/citizenstig/dvwa/) - `docker pull citizenstig/dvwa`.
-* [OWASP Juice Shop](https://github.com/bkimminich/juice-shop#docker-container--) - `docker pull bkimminich/juice-shop`.
-* [OWASP Mutillidae II Web Pen-Test Practice Application](https://hub.docker.com/r/citizenstig/nowasp/) - `docker pull citizenstig/nowasp`.
-* [OWASP NodeGoat](https://github.com/owasp/nodegoat#option-3---run-nodegoat-on-docker) - `docker-compose build && docker-compose up`.
-* [OWASP Security Shepherd](https://hub.docker.com/r/ismisepaul/securityshepherd/) - `docker pull ismisepaul/securityshepherd`.
-* [OWASP WebGoat Project 7.1 docker image](https://hub.docker.com/r/webgoat/webgoat-7.1/) - `docker pull webgoat/webgoat-7.1`.
-* [OWASP WebGoat Project 8.0 docker image](https://hub.docker.com/r/webgoat/webgoat-8.0/) - `docker pull webgoat/webgoat-8.0`.
-* [Vulnerability as a service: Heartbleed](https://hub.docker.com/r/hmlio/vaas-cve-2014-0160/) - `docker pull hmlio/vaas-cve-2014-0160`.
-* [Vulnerability as a service: SambaCry](https://hub.docker.com/r/vulnerables/cve-2017-7494/) - `docker pull vulnerables/cve-2017-7494`.
-* [Vulnerability as a service: Shellshock](https://hub.docker.com/r/hmlio/vaas-cve-2014-6271/) - `docker pull hmlio/vaas-cve-2014-6271`.
-* [Vulnerable WordPress Installation](https://hub.docker.com/r/wpscanteam/vulnerablewordpress/) - `docker pull wpscanteam/vulnerablewordpress`.
-
-### Docker Containers of Penetration Testing Distributions and Tools
-
-* [Docker Bench for Security](https://hub.docker.com/r/diogomonica/docker-bench-security/) - `docker pull diogomonica/docker-bench-security`.
-* [Official Kali Linux](https://hub.docker.com/r/kalilinux/kali-rolling/) - `docker pull kalilinux/kali-linux-docker`.
-* [Official OWASP ZAP](https://github.com/zaproxy/zaproxy) - `docker pull owasp/zap2docker-stable`.
-* [Official WPScan](https://hub.docker.com/r/wpscanteam/wpscan/) - `docker pull wpscanteam/wpscan`.
-* [Security Ninjas](https://hub.docker.com/r/opendns/security-ninjas/) - `docker pull opendns/security-ninjas`.
-* [docker-metasploit](https://hub.docker.com/r/phocean/msf/) - `docker pull phocean/msf`.
-
 ## Exfiltration Tools
 
 * [DET](https://github.com/sensepost/DET) - Proof of concept to perform data exfiltration using either single or multiple channel(s) at the same time.
@@ -344,6 +309,24 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 * [Industrial Exploitation Framework (ISF)](https://github.com/dark-lbp/isf) - Metasploit-like exploit framework based on routersploit designed to target Industrial Control Systems (ICS), SCADA devices, PLC firmware, and more.
 * [s7scan](https://github.com/klsecservices/s7scan) - Scanner for enumerating Siemens S7 PLCs on a TCP/IP or LLC network.
+
+## Intentionally Vulnerable Systems
+
+See also [awesome-vulnerable](https://github.com/kaiiyer/awesome-vulnerable).
+
+### Intentionally Vulnerable Systems as Docker Containers
+
+* [Damn Vulnerable Web Application (DVWA)](https://hub.docker.com/r/citizenstig/dvwa/) - `docker pull citizenstig/dvwa`.
+* [OWASP Juice Shop](https://github.com/bkimminich/juice-shop#docker-container--) - `docker pull bkimminich/juice-shop`.
+* [OWASP Mutillidae II Web Pen-Test Practice Application](https://hub.docker.com/r/citizenstig/nowasp/) - `docker pull citizenstig/nowasp`.
+* [OWASP NodeGoat](https://github.com/owasp/nodegoat#option-3---run-nodegoat-on-docker) - `docker-compose build && docker-compose up`.
+* [OWASP Security Shepherd](https://hub.docker.com/r/ismisepaul/securityshepherd/) - `docker pull ismisepaul/securityshepherd`.
+* [OWASP WebGoat Project 7.1 docker image](https://hub.docker.com/r/webgoat/webgoat-7.1/) - `docker pull webgoat/webgoat-7.1`.
+* [OWASP WebGoat Project 8.0 docker image](https://hub.docker.com/r/webgoat/webgoat-8.0/) - `docker pull webgoat/webgoat-8.0`.
+* [Vulnerability as a service: Heartbleed](https://hub.docker.com/r/hmlio/vaas-cve-2014-0160/) - `docker pull hmlio/vaas-cve-2014-0160`.
+* [Vulnerability as a service: SambaCry](https://hub.docker.com/r/vulnerables/cve-2017-7494/) - `docker pull vulnerables/cve-2017-7494`.
+* [Vulnerability as a service: Shellshock](https://hub.docker.com/r/hmlio/vaas-cve-2014-6271/) - `docker pull hmlio/vaas-cve-2014-6271`.
+* [Vulnerable WordPress Installation](https://hub.docker.com/r/wpscanteam/vulnerablewordpress/) - `docker pull wpscanteam/vulnerablewordpress`.
 
 ## Lock Picking
 
@@ -601,10 +584,6 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [Penetration Testing Framework (PTF)](http://www.vulnerabilityassessment.co.uk/Penetration%20Test.html) - Outline for performing penetration tests compiled as a general framework usable by vulnerability analysts and penetration testers alike.
 * [XSS-Payloads](http://www.xss-payloads.com) - Resource dedicated to all things XSS (cross-site), including payloads, tools, games, and documentation.
 
-### Online Social Engineering Resources
-
-* [Social Engineering Framework](http://www.social-engineer.org/framework/general-discussion/) - Information resource for social engineers.
-
 ### Other Lists Online
 
 * [.NET Programming](https://github.com/quozd/awesome-dotnet) - Software framework for Microsoft Windows platform development.
@@ -740,7 +719,24 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing), [*
 * [SGX-Step](https://github.com/jovanbulck/sgx-step) - Open-source framework to facilitate side-channel attack research on Intel x86 processors in general and Intel SGX (Software Guard Extensions) platforms in particular.
 * [TRRespass](https://github.com/vusec/trrespass) - Many-sided rowhammer tool suite able to reverse engineer the contents of DDR3 and DDR4 memory chips protected by Target Row Refresh mitigations.
 
-## Social Engineering Tools
+## Social Engineering
+
+See also [awesome-social-engineering](https://github.com/v2-dev/awesome-social-engineering).
+
+### Social Engineering Books
+
+* [Ghost in the Wires by Kevin D. Mitnick & William L. Simon, 2011](http://www.hachettebookgroup.com/titles/kevin-mitnick/ghost-in-the-wires/9780316134477/)
+* [No Tech Hacking by Johnny Long & Jack Wiles, 2008](https://www.elsevier.com/books/no-tech-hacking/mitnick/978-1-59749-215-7)
+* [Social Engineering in IT Security: Tools, Tactics, and Techniques by Sharon Conheady, 2014](https://www.mhprofessional.com/9780071818469-usa-social-engineering-in-it-security-tools-tactics-and-techniques-group)
+* [The Art of Deception by Kevin D. Mitnick & William L. Simon, 2002](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0471237124.html)
+* [The Art of Intrusion by Kevin D. Mitnick & William L. Simon, 2005](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0764569597.html)
+* [Unmasking the Social Engineer: The Human Element of Security by Christopher Hadnagy, 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118608577.html)
+
+### Social Engineering Online Resources
+
+* [Social Engineering Framework](http://www.social-engineer.org/framework/general-discussion/) - Information resource for social engineers.
+
+### Social Engineering Tools
 
 * [Beelogger](https://github.com/4w4k3/BeeLogger) - Tool for generating keylooger.
 * [Catphish](https://github.com/ring0lab/catphish) - Tool for phishing and corporate espionage written in Ruby.
@@ -829,6 +825,12 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing), [*
 * [wafw00f](https://github.com/EnableSecurity/wafw00f) - Identifies and fingerprints Web Application Firewall (WAF) products.
 * [webscreenshot](https://github.com/maaaaz/webscreenshot) - Simple script to take screenshots of websites from a list of sites.
 * [weevely3](https://github.com/epinna/weevely3) - Weaponized PHP-based web shell.
+
+### Web Exploitation Books
+
+* [The Browser Hacker's Handbook by Wade Alcorn et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118662091.html)
+* [The Web Application Hacker's Handbook by D. Stuttard, M. Pinto, 2011](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118026470.html)
+
 
 ## Windows Utilities
 

--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Tor Tools](#tor-tools)
 * [Anti-virus Evasion Tools](#anti-virus-evasion-tools)
 * [Books](#books)
-  * [Defensive Programming Books](#defensive-programming-books)
-  * [Hacker's Handbook Series Books](#hackers-handbook-series-books)
   * [Malware Analysis Books](#malware-analysis-books)
-  * [Network Analysis Books](#network-analysis-books)
   * [Penetration Testing Books](#penetration-testing-books)
-  * [Windows Books](#windows-books)
 * [CTF Tools](#ctf-tools)
 * [Collaboration Tools](#collaboration-tools)
 * [Conferences and Events](#conferences-and-events)
@@ -126,57 +122,33 @@ See also [awesome-tor](https://github.com/ajvb/awesome-tor).
 
 See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list.html).
 
-### Defensive Programming Books
-
-* [Holistic Info-Sec for Web Developers (Fascicle 0)](https://leanpub.com/holistic-infosec-for-web-developers)
-* [Holistic Info-Sec for Web Developers (Fascicle 1)](https://leanpub.com/holistic-infosec-for-web-developers-fascicle1-vps-network-cloud-webapplications)
-
-### Hacker's Handbook Series Books
-
-* [Android Hacker's Handbook by Joshua J. Drake et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-111860864X.html)
-* [Car Hacker's Handbook by Craig Smith, 2016](https://nostarch.com/carhacking)
-* [The Database Hacker's Handbook, David Litchfield et al., 2005](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0764578014.html)
-* [The Mac Hacker's Handbook by Charlie Miller & Dino Dai Zovi, 2009](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470395362.html)
-* [The Mobile Application Hacker's Handbook by Dominic Chell et al., 2015](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118958500.html)
-* [iOS Hacker's Handbook by Charlie Miller et al., 2012](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118204123.html)
-
-### Malware Analysis Books
-
-* [Malware Analyst's Cookbook and DVD by Michael Hale Ligh et al., 2010](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470613033.html)
-* [Practical Malware Analysis by Michael Sikorski & Andrew Honig, 2012](https://nostarch.com/malware)
-* [The Art of Memory Forensics by Michael Hale Ligh et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118825098.html)
-
-### Network Analysis Books
-
-* [Network Forensics: Tracking Hackers through Cyberspace by Sherri Davidoff & Jonathan Ham, 2012](http://www.amazon.com/Network-Forensics-Tracking-Hackers-Cyberspace-ebook/dp/B008CG8CYU/)
-* [Nmap Network Scanning by Gordon Fyodor Lyon, 2009](https://nmap.org/book/)
-* [Practical Packet Analysis by Chris Sanders, 2011](https://nostarch.com/packet2.htm)
-* [Wireshark Network Analysis by by Laura Chappell & Gerald Combs, 2012](https://www.amazon.com/Wireshark-Network-Analysis-Second-Certified/dp/1893939944)
-
-### Penetration Testing Books
-
 * [Advanced Penetration Testing by Wil Allsopp, 2017](https://www.amazon.com/Advanced-Penetration-Testing-Hacking-Networks/dp/1119367689/)
 * [Advanced Penetration Testing for Highly-Secured Environments by Lee Allen, 2012](http://www.packtpub.com/networking-and-servers/advanced-penetration-testing-highly-secured-environments-ultimate-security-gu)
 * [Advanced Persistent Threat Hacking: The Art and Science of Hacking Any Organization by Tyler Wrightson, 2014](http://www.amazon.com/Advanced-Persistent-Threat-Hacking-Organization/dp/0071828362)
+* [Android Hacker's Handbook by Joshua J. Drake et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-111860864X.html)
+* [BTFM: Blue Team Field Manual by Alan J White & Ben Clark, 2017](https://www.amazon.de/Blue-Team-Field-Manual-BTFM/dp/154101636X)
 * [Black Hat Python: Python Programming for Hackers and Pentesters by Justin Seitz, 2014](http://www.amazon.com/Black-Hat-Python-Programming-Pentesters/dp/1593275900)
-* [Btfm: Blue Team Field Manual by Alan J White & Ben Clark, 2017](https://www.amazon.de/Blue-Team-Field-Manual-BTFM/dp/154101636X)
 * [Bug Hunter's Diary by Tobias Klein, 2011](https://nostarch.com/bughunter)
+* [Car Hacker's Handbook by Craig Smith, 2016](https://nostarch.com/carhacking)
 * [Fuzzing: Brute Force Vulnerability Discovery by Michael Sutton et al., 2007](http://www.fuzzing.org/)
 * [Metasploit: The Penetration Tester's Guide by David Kennedy et al., 2011](https://nostarch.com/metasploit)
 * [Penetration Testing: A Hands-On Introduction to Hacking by Georgia Weidman, 2014](https://nostarch.com/pentesting)
 * [Penetration Testing: Procedures & Methodologies by EC-Council, 2010](http://www.amazon.com/Penetration-Testing-Procedures-Methodologies-EC-Council/dp/1435483677)
 * [Professional Penetration Testing by Thomas Wilhelm, 2013](https://www.elsevier.com/books/professional-penetration-testing/wilhelm/978-1-59749-993-4)
-* [Rtfm: Red Team Field Manual by Ben Clark, 2014](http://www.amazon.com/Rtfm-Red-Team-Field-Manual/dp/1494295504/)
+* [RTFM: Red Team Field Manual by Ben Clark, 2014](http://www.amazon.com/Rtfm-Red-Team-Field-Manual/dp/1494295504/)
 * [The Art of Exploitation by Jon Erickson, 2008](https://nostarch.com/hacking2.htm)
 * [The Basics of Hacking and Penetration Testing by Patrick Engebretson, 2013](https://www.elsevier.com/books/the-basics-of-hacking-and-penetration-testing/engebretson/978-1-59749-655-1)
+* [The Database Hacker's Handbook, David Litchfield et al., 2005](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0764578014.html)
 * [The Hacker Playbook by Peter Kim, 2014](http://www.amazon.com/The-Hacker-Playbook-Practical-Penetration/dp/1494932636/)
+* [The Mac Hacker's Handbook by Charlie Miller & Dino Dai Zovi, 2009](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470395362.html)
+* [The Mobile Application Hacker's Handbook by Dominic Chell et al., 2015](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118958500.html)
 * [Unauthorised Access: Physical Penetration Testing For IT Security Teams by Wil Allsopp, 2010](http://www.amazon.com/Unauthorised-Access-Physical-Penetration-Security-ebook/dp/B005DIAPKE)
 * [Violent Python by TJ O'Connor, 2012](https://www.elsevier.com/books/violent-python/unknown/978-1-59749-957-6)
+* [iOS Hacker's Handbook by Charlie Miller et al., 2012](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118204123.html)
 
-### Windows Books
+### Malware Analysis Books
 
-* [Troubleshooting with the Windows Sysinternals Tools by Mark Russinovich & Aaron Margosis, 2016](https://www.amazon.com/Troubleshooting-Windows-Sysinternals-Tools-2nd/dp/0735684448/)
-* [Windows Internals by Mark Russinovich et al., 2012](http://www.amazon.com/Windows-Internals-Part-Developer-Reference/dp/0735648735/)
+See [awesome-malware-analysis § Books](https://github.com/rshipp/awesome-malware-analysis#books).
 
 ## CTF Tools
 
@@ -530,7 +502,6 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [Security-related Operating Systems](https://list.rawsec.ml/operating_systems.html) - List of security related operating systems.
 * [JavaScript Programming](https://github.com/sorrycc/awesome-javascript) - In-browser development and scripting.
 * [Kali Linux Tools](http://tools.kali.org/tools-listing) - List of tools present in Kali Linux.
-* [Malware Analysis](https://github.com/rshipp/awesome-malware-analysis) - Tools and resources for analysts.
 * [Node.js Programming by @sindresorhus](https://github.com/sindresorhus/awesome-nodejs) - Curated list of delightful Node.js packages and resources.
 * [Pentest Cheat Sheets](https://github.com/coreb1t/awesome-pentest-cheat-sheets) - Awesome Pentest Cheat Sheets.
 * [Python Programming by @svaksha](https://github.com/svaksha/pythonidae) - General Python programming.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Books](#books)
   * [Defensive Programming Books](#defensive-programming-books)
   * [Hacker's Handbook Series Books](#hackers-handbook-series-books)
-  * [Lock Picking Books](#lock-picking-books)
   * [Malware Analysis Books](#malware-analysis-books)
   * [Network Analysis Books](#network-analysis-books)
   * [Penetration Testing Books](#penetration-testing-books)
@@ -42,6 +41,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Hash Cracking Tools](#hash-cracking-tools)
 * [Hex Editors](#hex-editors)
 * [Industrial Control and SCADA Systems](#industrial-control-and-scada-systems)
+* [Lock Picking](#lock-picking)
 * [macOS Utilities](#macos-utilities)
 * [Multi-paradigm Frameworks](#multi-paradigm-frameworks)
 * [Network Tools](#network-tools)
@@ -139,13 +139,6 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [The Shellcoder's Handbook by Chris Anley et al., 2007](http://www.wiley.com/WileyCDA/WileyTitle/productCd-047008023X.html)
 * [The Web Application Hacker's Handbook by D. Stuttard, M. Pinto, 2011](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118026470.html)
 * [iOS Hacker's Handbook by Charlie Miller et al., 2012](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118204123.html)
-
-### Lock Picking Books
-
-* [Eddie the Wire books](https://www.dropbox.com/sh/k3z4dm4vyyojp3o/AAAIXQuwMmNuCch_StLPUYm-a?dl=0)
-* [Keys to the Kingdom by Deviant Ollam, 2012](https://www.elsevier.com/books/keys-to-the-kingdom/ollam/978-1-59749-983-5)
-* [Lock Picking: Detail Overkill by Solomon](https://www.dropbox.com/s/y39ix9u9qpqffct/Lockpicking%20Detail%20Overkill.pdf?dl=0)
-* [Practical Lock Picking by Deviant Ollam, 2012](https://www.elsevier.com/books/practical-lock-picking/ollam/978-1-59749-989-7)
 
 ### Malware Analysis Books
 
@@ -366,6 +359,10 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 * [Industrial Exploitation Framework (ISF)](https://github.com/dark-lbp/isf) - Metasploit-like exploit framework based on routersploit designed to target Industrial Control Systems (ICS), SCADA devices, PLC firmware, and more.
 * [s7scan](https://github.com/klsecservices/s7scan) - Scanner for enumerating Siemens S7 PLCs on a TCP/IP or LLC network.
 
+## Lock Picking
+
+See [awesome-lockpicking](https://github.com/fabacab/awesome-lockpicking).
+
 ## macOS Utilities
 
 * [Bella](https://github.com/kdaoudieh/Bella) - Pure Python post-exploitation data mining and remote administration tool for macOS.
@@ -492,12 +489,13 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [KRACK Detector](https://github.com/securingsam/krackdetector) - Detect and prevent KRACK attacks in your network.
 * [Kismet](https://kismetwireless.net/) - Wireless network detector, sniffer, and IDS.
 * [PSKracker](https://github.com/soxrok2212/PSKracker) - Collection of WPA/WPA2/WPS default algorithms, password generators, and PIN generators written in C.
-* [pwnagotchi](https://github.com/evilsocket/pwnagotchi) - Deep reinforcement learning based AI that learns from the Wi-Fi environment and instruments BetterCAP in order to maximize the WPA key material captured.
 * [Reaver](https://code.google.com/archive/p/reaver-wps) - Brute force attack against WiFi Protected Setup.
+* [WiFi Pineapple](https://www.wifipineapple.com/) - Wireless auditing and penetration testing platform.
 * [WiFi-Pumpkin](https://github.com/P0cL4bs/WiFi-Pumpkin) - Framework for rogue Wi-Fi access point attack.
 * [Wifite](https://github.com/derv82/wifite) - Automated wireless attack tool.
 * [infernal-twin](https://github.com/entropy1337/infernal-twin) - Automated wireless hacking tool.
 * [krackattacks-scripts](https://github.com/vanhoefm/krackattacks-scripts) - WPA2 Krack attack scripts.
+* [pwnagotchi](https://github.com/evilsocket/pwnagotchi) - Deep reinforcement learning based AI that learns from the Wi-Fi environment and instruments BetterCAP in order to maximize the WPA key material captured.
 * [wifi-arsenal](https://github.com/0x90/wifi-arsenal) - Resources for Wi-Fi Pentesting.
 
 ## Network Vulnerability Scanners
@@ -594,12 +592,6 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database.
 * [Shellcode Tutorial](http://www.vividmachines.com/shellcode/shellcode.html) - Tutorial on how to write shellcode.
 
-### Online Lock Picking Resources
-
-* [/r/lockpicking](https://www.reddit.com/r/lockpicking) - Resources for learning lockpicking, equipment recommendations.
-* [Schuyler Towne channel](https://www.youtube.com/user/SchuylerTowne/) - Lockpicking videos and security talks.
-* [bosnianbill](https://www.youtube.com/user/bosnianbill) - Instructional lockpicking videos made by an expert.
-
 ### Online Open Sources Intelligence (OSINT) Resources
 
 * [CertGraph](https://github.com/lanrat/certgraph) - Crawls a domain's SSL/TLS certificates for its certificate alternative names.
@@ -635,7 +627,6 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [Android Security](https://github.com/ashishb/android-security-awesome) - Collection of Android security related resources.
 * [AppSec](https://github.com/paragonie/awesome-appsec) - Resources for learning about application security.
 * [Awesome Awesomness](https://github.com/bayandin/awesome-awesomeness) - The List of the Lists.
-* [Awesome Lockpicking](https://github.com/meitar/awesome-lockpicking) - Awesome guides, tools, and other resources about the security and compromise of locks, safes, and keys.
 * [Awesome Shodan Queries](https://github.com/jakejarvis/awesome-shodan-queries) - Awesome list of useful, funny, and depressing search queries for Shodan.
 * [AWS Tool Arsenal](https://github.com/toniblyx/my-arsenal-of-aws-security-tools) - List of tools for testing and securing AWS environments.
 * [Blue Team](https://github.com/fabacab/awesome-cybersecurity-blueteam) - Awesome resources, tools, and other shiny things for cybersecurity blue teams.
@@ -704,11 +695,10 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [Proxmark3](https://proxmark3.com/) - RFID/NFC cloning, replay, and spoofing toolkit often used for analyzing and attacking proximity cards/readers, wireless keys/keyfobs, and more.
 * [Thunderclap](https://thunderclap.io/) - Open source I/O security research platform for auditing physical DMA-enabled hardware peripheral ports.
 * [USB Rubber Ducky](http://usbrubberducky.com/) - Customizable keystroke injection attack platform masquerading as a USB thumbdrive.
-* [WiFi Pineapple](https://www.wifipineapple.com/) - Wireless auditing and penetration testing platform.
 
 ## Reverse Engineering Tools
 
-See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
+See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing), [*Exploit Development Tools*](#exploit-development-tools).
 
 * [Capstone](http://www.capstone-engine.org/) - Lightweight multi-platform, multi-architecture disassembly framework.
 * [Evan's Debugger](http://www.codef00.com/projects#debugger) - OllyDbg-like debugger for GNU/Linux.

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Reverse Engineering Books](#reverse-engineering-books)
   * [Reverse Engineering Tools](#reverse-engineering-tools)
 * [Security Education Courses](#security-education-courses)
+* [Shellcoding Guides and Tutorials](#exploit-development-online-resources)
 * [Side-channel Tools](#side-channel-tools)
 * [Social Engineering](#social-engineering)
   * [Social Engineering Books](#social-engineering-books)
@@ -139,7 +140,6 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [The Database Hacker's Handbook, David Litchfield et al., 2005](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0764578014.html)
 * [The Mac Hacker's Handbook by Charlie Miller & Dino Dai Zovi, 2009](http://www.wiley.com/WileyCDA/WileyTitle/productCd-0470395362.html)
 * [The Mobile Application Hacker's Handbook by Dominic Chell et al., 2015](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118958500.html)
-* [The Shellcoder's Handbook by Chris Anley et al., 2007](http://www.wiley.com/WileyCDA/WileyTitle/productCd-047008023X.html)
 * [iOS Hacker's Handbook by Charlie Miller et al., 2012](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118204123.html)
 
 ### Malware Analysis Books
@@ -263,6 +263,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 See also *[Reverse Engineering Tools](#reverse-engineering-tools)*.
 
+* [Magic Unicorn](https://github.com/trustedsec/unicorn) - Shellcode generator for numerous attack vectors, including Microsoft Office macros, PowerShell, HTML applications (HTA), or `certutil` (using fake certificates).
 * [Pwntools](https://github.com/Gallopsled/pwntools) - Rapid exploit development framework built for use in CTFs.
 * [peda](https://github.com/longld/peda) - Python Exploit Development Assistance for GDB.
 * [Wordpress Exploit Framework](https://github.com/rastating/wordpress-exploit-framework) - Ruby framework for developing and using modules which aid in the penetration testing of WordPress powered websites and systems.
@@ -495,16 +496,6 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 
 ## Online Resources
 
-### Online Code Samples and Examples
-
-* [goHackTools](https://github.com/dreddsa5dies/goHackTools) - Hacker tools on Go (Golang).
-
-### Online Exploit Development Resources
-
-* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to develop exploits.
-* [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database.
-* [Shellcode Tutorial](http://www.vividmachines.com/shellcode/shellcode.html) - Tutorial on how to write shellcode.
-
 ### Online Operating Systems Resources
 
 * [DistroWatch.com's Security Category](https://distrowatch.com/search.php?category=Security) - Website dedicated to talking about, reviewing, and keeping up to date with open source operating systems.
@@ -718,6 +709,13 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing), [*
 * [Open Security Training](http://opensecuritytraining.info/) - Training material for computer security classes.
 * [SANS Security Training](http://www.sans.org/) - Computer Security Training & Certification.
 
+## Shellcoding Guides and Tutorials
+
+* [Exploit Writing Tutorials](https://www.corelan.be/index.php/2009/07/19/exploit-writing-tutorial-part-1-stack-based-overflows/) - Tutorials on how to develop exploits.
+* [Shellcode Examples](http://shell-storm.org/shellcode/) - Shellcodes database.
+* [Shellcode Tutorial](http://www.vividmachines.com/shellcode/shellcode.html) - Tutorial on how to write shellcode.
+* [The Shellcoder's Handbook by Chris Anley et al., 2007](http://www.wiley.com/WileyCDA/WileyTitle/productCd-047008023X.html)
+
 ## Side-channel Tools
 
 * [ChipWhisperer](http://chipwhisperer.com) - Complete open-source toolchain for side-channel power analysis and glitching attacks.
@@ -848,7 +846,6 @@ See also [awesome-social-engineering](https://github.com/v2-dev/awesome-social-e
 * [Fibratus](https://github.com/rabbitstack/fibratus) - Tool for exploration and tracing of the Windows kernel.
 * [Inveigh](https://github.com/Kevin-Robertson/Inveigh) - Windows PowerShell ADIDNS/LLMNR/mDNS/NBNS spoofer/machine-in-the-middle tool.
 * [LaZagne](https://github.com/AlessandroZ/LaZagne) - Credentials recovery project.
-* [Magic Unicorn](https://github.com/trustedsec/unicorn) - Shellcode generator for numerous attack vectors, including Microsoft Office macros, PowerShell, HTML applications (HTA), or `certutil` (using fake certificates).
 * [MailSniper](https://github.com/dafthack/MailSniper) - Modular tool for searching through email in a Microsoft Exchange environment, gathering the Global Address List from Outlook Web Access (OWA) and Exchange Web Services (EWS), and more.
 * [PowerSploit](https://github.com/PowerShellMafia/PowerSploit) - PowerShell Post-Exploitation Framework.
 * [RID_ENUM](https://github.com/trustedsec/ridenum) - Python script that can enumerate all users from a Windows Domain Controller and crack those user's passwords using brute-force.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Malware Analysis Books](#malware-analysis-books)
   * [Network Analysis Books](#network-analysis-books)
   * [Penetration Testing Books](#penetration-testing-books)
-  * [Reverse Engineering Books](#reverse-engineering-books)
   * [Social Engineering Books](#social-engineering-books)
   * [Windows Books](#windows-books)
 * [CTF Tools](#ctf-tools)
@@ -75,7 +74,9 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Periodicals](#periodicals)
 * [Physical Access Tools](#physical-access-tools)
 * [Privilege Escalation Tools](#privilege-escalation-tools)
-* [Reverse Engineering Tools](#reverse-engineering-tools)
+* [Reverse Engineering](#reverse-engineering)
+  * [Reverse Engineering Books](#reverse-engineering-books)
+  * [Reverse Engineering Tools](#reverse-engineering-tools)
 * [Security Education Courses](#security-education-courses)
 * [Side-channel Tools](#side-channel-tools)
 * [Social Engineering Tools](#social-engineering-tools)
@@ -172,21 +173,6 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [The Hacker Playbook by Peter Kim, 2014](http://www.amazon.com/The-Hacker-Playbook-Practical-Penetration/dp/1494932636/)
 * [Unauthorised Access: Physical Penetration Testing For IT Security Teams by Wil Allsopp, 2010](http://www.amazon.com/Unauthorised-Access-Physical-Penetration-Security-ebook/dp/B005DIAPKE)
 * [Violent Python by TJ O'Connor, 2012](https://www.elsevier.com/books/violent-python/unknown/978-1-59749-957-6)
-
-## Privilege Escalation Tools
-
-* [Active Directory and Privilege Escalation (ADAPE)](https://github.com/hausec/ADAPE-Script) - Umbrella script that automates numerous useful PowerShell modules to discover security misconfigurations and attempt privilege escalation against Active Directory.
-* [LinEnum](https://github.com/rebootuser/LinEnum) - Scripted local Linux enumeration and privilege escalation checker useful for auditing a host and during CTF gaming.
-* [Postenum](https://github.com/mbahadou/postenum) - Shell script used for enumerating possible privilege escalation opportunities on a local GNU/Linux system.
-* [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
-
-## Reverse Engineering Books
-
-* [Gray Hat Hacking The Ethical Hacker's Handbook by Daniel Regalado et al., 2015](http://www.amazon.com/Hacking-Ethical-Hackers-Handbook-Edition/dp/0071832386)
-* [Hacking the Xbox by Andrew Huang, 2003](https://nostarch.com/xbox.htm)
-* [Practical Reverse Engineering by Bruce Dang et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118787315.html)
-* [Reverse Engineering for Beginners by Dennis Yurichev](http://beginners.re/)
-* [The IDA Pro Book by Chris Eagle, 2011](https://nostarch.com/idapro2.htm)
 
 ### Social Engineering Books
 
@@ -696,9 +682,26 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 * [Thunderclap](https://thunderclap.io/) - Open source I/O security research platform for auditing physical DMA-enabled hardware peripheral ports.
 * [USB Rubber Ducky](http://usbrubberducky.com/) - Customizable keystroke injection attack platform masquerading as a USB thumbdrive.
 
-## Reverse Engineering Tools
+## Privilege Escalation Tools
+
+* [Active Directory and Privilege Escalation (ADAPE)](https://github.com/hausec/ADAPE-Script) - Umbrella script that automates numerous useful PowerShell modules to discover security misconfigurations and attempt privilege escalation against Active Directory.
+* [LinEnum](https://github.com/rebootuser/LinEnum) - Scripted local Linux enumeration and privilege escalation checker useful for auditing a host and during CTF gaming.
+* [Postenum](https://github.com/mbahadou/postenum) - Shell script used for enumerating possible privilege escalation opportunities on a local GNU/Linux system.
+* [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
+
+## Reverse Engineering
 
 See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing), [*Exploit Development Tools*](#exploit-development-tools).
+
+### Reverse Engineering Books
+
+* [Gray Hat Hacking The Ethical Hacker's Handbook by Daniel Regalado et al., 2015](http://www.amazon.com/Hacking-Ethical-Hackers-Handbook-Edition/dp/0071832386)
+* [Hacking the Xbox by Andrew Huang, 2003](https://nostarch.com/xbox.htm)
+* [Practical Reverse Engineering by Bruce Dang et al., 2014](http://www.wiley.com/WileyCDA/WileyTitle/productCd-1118787315.html)
+* [Reverse Engineering for Beginners by Dennis Yurichev](http://beginners.re/)
+* [The IDA Pro Book by Chris Eagle, 2011](https://nostarch.com/idapro2.htm)
+
+### Reverse Engineering Tools
 
 * [Capstone](http://www.capstone-engine.org/) - Lightweight multi-platform, multi-architecture disassembly framework.
 * [Evan's Debugger](http://www.codef00.com/projects#debugger) - OllyDbg-like debugger for GNU/Linux.

--- a/README.md
+++ b/README.md
@@ -57,9 +57,8 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Email search and analysis tools](#email-search-and-analysis-tools)
   * [Metadata harvesting and analysis](#metadata-harvesting-and-analysis)
   * [Network device discovery tools](#network-device-discovery-tools)
-  * [Source code repository searching tools](#source-code-repository-searching-tools)
   * [OSINT Online Resources](#osint-online-resources)
-  * [OSINT Tools](#osint-tools)
+  * [Source code repository searching tools](#source-code-repository-searching-tools)
 * [Online Resources](#online-resources)
   * [Online Code Samples and Examples](#online-code-samples-and-examples)
   * [Online Exploit Development Resources](#online-exploit-development-resources)
@@ -68,7 +67,6 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [Online Penetration Testing Resources](#online-penetration-testing-resources)
   * [Other Lists Online](#other-lists-online)
   * [Penetration Testing Report Templates](#penetration-testing-report-templates)
-* [Open Sources Intelligence (OSINT)](#open-sources-intelligence-osint)
 * [Operating System Distributions](#operating-system-distributions)
 * [Periodicals](#periodicals)
 * [Physical Access Tools](#physical-access-tools)
@@ -560,6 +558,21 @@ See also [awesome-pcaptools](https://github.com/caesar0301/awesome-pcaptools).
 
 See also [awesome-osint](https://github.com/jivoi/awesome-osint).
 
+* [DataSploit](https://github.com/upgoingstar/datasploit) - OSINT visualizer utilizing Shodan, Censys, Clearbit, EmailHunter, FullContact, and Zoomeye behind the scenes.
+* [GyoiThon](https://github.com/gyoisamurai/GyoiThon) - GyoiThon is an Intelligence Gathering tool using Machine Learning.
+* [Intrigue](http://intrigue.io) - Automated OSINT & Attack Surface discovery framework with powerful API, UI and CLI.
+* [Maltego](http://www.maltego.com/) - Proprietary software for open sources intelligence and forensics.
+* [PacketTotal](https://packettotal.com/) - Simple, free, high-quality packet capture file analysis facilitating the quick detection of network-borne malware (using Zeek and Suricata IDS signatures under the hood).
+* [Skiptracer](https://github.com/xillwillx/skiptracer) - OSINT scraping framework that utilizes basic Python webscraping (BeautifulSoup) of PII paywall sites to compile passive information on a target on a ramen noodle budget.
+* [Sn1per](https://github.com/1N3/Sn1per) - Automated Pentest Recon Scanner.
+* [Spiderfoot](http://www.spiderfoot.net/) - Multi-source OSINT automation tool with a Web UI and report visualizations.
+* [creepy](https://github.com/ilektrojohn/creepy) - Geolocation OSINT tool.
+* [gOSINT](https://github.com/Nhoya/gOSINT) - OSINT tool with multiple modules and a telegram scraper.
+* [image-match](https://github.com/ascribe/image-match) - Quickly search over billions of images.
+* [recon-ng](https://github.com/lanmaster53/recon-ng) - Full-featured Web Reconnaissance framework written in Python.
+* [sn0int](https://github.com/kpcyrd/sn0int) - Semi-automatic OSINT framework and package manager.
+
+
 ### Data Broker and Search Engine Services
 
 * [Hunter.io](https://hunter.io/) - Data broker providing a Web search interface for discovering the email addresses and other organizational details of a company.
@@ -597,11 +610,6 @@ See also [awesome-osint](https://github.com/jivoi/awesome-osint).
 * [Shodan](https://www.shodan.io/) - World's first search engine for Internet-connected devices.
 * [ZoomEye](https://www.zoomeye.org/) - Search engine for cyberspace that lets the user find specific network components.
 
-### Source code repository searching tools
-
-* [vcsmap](https://github.com/melvinsh/vcsmap) - Plugin-based tool to scan public version control systems for sensitive information.
-* [Yar](https://github.com/Furduhlutur/yar) - Clone git repositories to search through the whole commit history in order of commit time for secrets, tokens, or passwords.
-
 ### OSINT Online Resources
 
 * [CertGraph](https://github.com/lanrat/certgraph) - Crawls a domain's SSL/TLS certificates for its certificate alternative names.
@@ -610,21 +618,10 @@ See also [awesome-osint](https://github.com/jivoi/awesome-osint).
 * [OSINT Framework](http://osintframework.com/) - Collection of various OSINT tools broken out by category.
 * [WiGLE.net](https://wigle.net/) - Information about wireless networks world-wide, with user-friendly desktop and web applications.
 
-### OSINT Tools
+### Source code repository searching tools
 
-* [DataSploit](https://github.com/upgoingstar/datasploit) - OSINT visualizer utilizing Shodan, Censys, Clearbit, EmailHunter, FullContact, and Zoomeye behind the scenes.
-* [GyoiThon](https://github.com/gyoisamurai/GyoiThon) - GyoiThon is an Intelligence Gathering tool using Machine Learning.
-* [Intrigue](http://intrigue.io) - Automated OSINT & Attack Surface discovery framework with powerful API, UI and CLI.
-* [Maltego](http://www.maltego.com/) - Proprietary software for open sources intelligence and forensics.
-* [PacketTotal](https://packettotal.com/) - Simple, free, high-quality packet capture file analysis facilitating the quick detection of network-borne malware (using Bro and Suricata IDS signatures under the hood).
-* [Skiptracer](https://github.com/xillwillx/skiptracer) - OSINT scraping framework that utilizes basic Python webscraping (BeautifulSoup) of PII paywall sites to compile passive information on a target on a ramen noodle budget.
-* [Sn1per](https://github.com/1N3/Sn1per) - Automated Pentest Recon Scanner.
-* [Spiderfoot](http://www.spiderfoot.net/) - Multi-source OSINT automation tool with a Web UI and report visualizations.
-* [creepy](https://github.com/ilektrojohn/creepy) - Geolocation OSINT tool.
-* [gOSINT](https://github.com/Nhoya/gOSINT) - OSINT tool with multiple modules and a telegram scraper.
-* [image-match](https://github.com/ascribe/image-match) - Quickly search over billions of images.
-* [recon-ng](https://github.com/lanmaster53/recon-ng) - Full-featured Web Reconnaissance framework written in Python.
-* [sn0int](https://github.com/kpcyrd/sn0int) - Semi-automatic OSINT framework and package manager.
+* [vcsmap](https://github.com/melvinsh/vcsmap) - Plugin-based tool to scan public version control systems for sensitive information.
+* [Yar](https://github.com/Furduhlutur/yar) - Clone git repositories to search through the whole commit history in order of commit time for secrets, tokens, or passwords.
 
 ## Operating System Distributions
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Awesome Penetration Testing [![Awesome](https://awesome.re/badge-flat2.svg)](https://awesome.re)
 
-> A collection of awesome penetration testing resources.
+> A collection of awesome penetration testing and offensive cybersecurity resources.
 
 [Penetration testing](https://en.wikipedia.org/wiki/Penetration_test) is the practice of launching authorized, simulated attacks against computer systems and their physical infrastructure to expose potential security weaknesses and vulnerabilities.
 
@@ -70,6 +70,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Operating System Distributions](#operating-system-distributions)
 * [Periodicals](#periodicals)
 * [Physical Access Tools](#physical-access-tools)
+* [Privilege Escalation Tools](#privilege-escalation-tools)
 * [Reverse Engineering Tools](#reverse-engineering-tools)
 * [Security Education Courses](#security-education-courses)
 * [Side-channel Tools](#side-channel-tools)
@@ -165,6 +166,13 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 * [Unauthorised Access: Physical Penetration Testing For IT Security Teams by Wil Allsopp, 2010](http://www.amazon.com/Unauthorised-Access-Physical-Penetration-Security-ebook/dp/B005DIAPKE)
 * [Violent Python by TJ O'Connor, 2012](https://www.elsevier.com/books/violent-python/unknown/978-1-59749-957-6)
 
+### Privilege Escalation Tools
+
+* [Active Directory and Privilege Escalation (ADAPE)](https://github.com/hausec/ADAPE-Script) - Umbrella script that automates numerous useful PowerShell modules to discover security misconfigurations and attempt privilege escalation against Active Directory.
+* [LinEnum](https://github.com/rebootuser/LinEnum) - Scripted local Linux enumeration and privilege escalation checker useful for auditing a host and during CTF gaming.
+* [Postenum](https://github.com/mbahadou/postenum) - Shell script used for enumerating possible privilege escalation opportunities on a local GNU/Linux system.
+* [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
+
 ### Reverse Engineering Books
 
 * [Gray Hat Hacking The Ethical Hacker's Handbook by Daniel Regalado et al., 2015](http://www.amazon.com/Hacking-Ethical-Hackers-Handbook-Edition/dp/0071832386)
@@ -197,7 +205,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 ## Collaboration Tools
 
-* [Dradis](https://dradisframework.com) - Open-source reporting and collaboration tool for IT security professionals. 
+* [Dradis](https://dradisframework.com) - Open-source reporting and collaboration tool for IT security professionals.
 * [Lair](https://github.com/lair-framework/lair/wiki) - Reactive attack collaboration framework and web application built with meteor.
 * [RedELK](https://github.com/outflanknl/RedELK) - Track and alarm about Blue Team activities while providing better usability in long term offensive operations.
 
@@ -292,12 +300,9 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 ## GNU/Linux Utilities
 
 * [Hwacha](https://github.com/n00py/Hwacha) - Post-exploitation tool to quickly execute payloads via SSH on one or more Linux systems simultaneously.
-* [LinEnum](https://github.com/rebootuser/LinEnum) - Scripted local Linux enumeration and privilege escalation checker useful for auditing a host and during CTF gaming.
 * [Linux Exploit Suggester](https://github.com/PenturaLabs/Linux_Exploit_Suggester) - Heuristic reporting on potentially viable exploits for a given GNU/Linux system.
 * [Lynis](https://cisofy.com/lynis/) - Auditing tool for UNIX-based systems.
-* [Postenum](https://github.com/mbahadou/postenum) - Shell script used for enumerating possible privilege escalation opportunities on a local GNU/Linux system. 
 * [checksec.sh](https://www.trapkit.de/tools/checksec.html) - Shell script designed to test what standard Linux OS and PaX security features are being used.
-* [unix-privesc-check](https://github.com/pentestmonkey/unix-privesc-check) - Shell script to check for simple privilege escalation vectors on UNIX systems.
 
 ## Hash Cracking Tools
 
@@ -327,7 +332,7 @@ See also [DEF CON Suggested Reading](https://www.defcon.org/html/links/book-list
 
 See also [awesome-industrial-control-system-security](https://github.com/hslatman/awesome-industrial-control-system-security).
 
-* [Industrial Exploitation Framework (ISF)](https://github.com/dark-lbp/isf) - Metasploit-like exploit framework based on routersploit designed to target Industrial Control Systems (ICS), SCADA devices, PLC firmware, and more. 
+* [Industrial Exploitation Framework (ISF)](https://github.com/dark-lbp/isf) - Metasploit-like exploit framework based on routersploit designed to target Industrial Control Systems (ICS), SCADA devices, PLC firmware, and more.
 * [s7scan](https://github.com/klsecservices/s7scan) - Scanner for enumerating Siemens S7 PLCs on a TCP/IP or LLC network.
 
 ## Multi-paradigm Frameworks
@@ -812,7 +817,6 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 
 ## Windows Utilities
 
-* [Active Directory and Privilege Escalation (ADAPE)](https://github.com/hausec/ADAPE-Script) - Umbrella script that automates numerous useful PowerShell modules to discover security misconfigurations and attempt privilege escalation against Active Directory.
 * [Bloodhound](https://github.com/adaptivethreat/Bloodhound/wiki) - Graphical Active Directory trust relationship explorer.
 * [Commando VM](https://github.com/fireeye/commando-vm) - Automated installation of over 140 Windows software packages for penetration testing and red teaming.
 * [Covenant](https://github.com/cobbr/Covenant) - ASP.NET Core application that serves as a collaborative command and control platform for red teamers.


### PR DESCRIPTION
This is a work in progress PR showing a direction for consolidating numerous list sections and more clearly categorizing certain tools. The major goals of this work are:

* Lessen ambiguous areas such as "other lists elsewhere" and "network tools" that have grown long and less clear over time.
* More clearly delineate the purpose of a given tool or resource. For example, some items are clearly "educational" (labs, books, intentionally vulnerable systems, so forth) while others are "reference," and there are several places where these intentions are mixed.
* Ensure each block items listed are appropriate for the heading and all its ancestor headings. (For example, steganography tools that don't touch a network shouldn't be in the "network tools" section.)

Some of the techniques I'll use for this reorganization are primarily:

* Choose more specific section headings or create subheadings where appropriate. For example: Anonymity Tools has a new subsection for Tor.
* Offload work to actively maintained specialized lists where appropriate. For example: all the lock picking resources we listed are removed as they are available in a specialized Awesome Lockpicking list that we already linked to in the "Other Lists Elsewhere" section. This can be done using one of two methods, on a case-by-case basis:
  * A new top-level section that links to another list elsewhere, when the topic is "big" enough as judged by prior content in our own list.
  * A "See also" link in an appropriate existing section of our own list.

This PR starts the above process and is in a merge-ready state, but the overall work cited above should not yet be considered complete.