### PR TITLE
Update link to shellphish

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ See also [awesome-reversing](https://github.com/tylerha97/awesome-reversing).
 * [King Phisher](https://github.com/securestate/king-phisher) - Phishing campaign toolkit used for creating and managing multiple simultaneous phishing attacks with custom email and server content.
 * [Modlishka](https://github.com/drk1wi/Modlishka) - Flexible and powerful reverse proxy with real-time two-factor authentication.
 * [ReelPhish](https://github.com/fireeye/ReelPhish) - Real-time two-factor phishing tool.
-* [ShellPhish](https://github.com/thelinuxchoice/shellphish) - Social media site cloner and phishing tool built atop SocialFish.
+* [ShellPhish](https://github.com/suljot/shellphish) - Social media site cloner and phishing tool built atop SocialFish.
 * [Social Engineer Toolkit (SET)](https://github.com/trustedsec/social-engineer-toolkit) - Open source pentesting framework designed for social engineering featuring a number of custom attack vectors to make believable attacks quickly.
 * [SocialFish](https://github.com/UndeadSec/SocialFish) - Social media phishing framework that can run on an Android phone or in a Docker container.
 * [phishery](https://github.com/ryhanson/phishery) - TLS/SSL enabled Basic Auth credential harvester.


### PR DESCRIPTION
Shellphish should either be removed or the link updated as the original repository is not available anymore