### PR TITLE
Add Dropper category and add CurlNexec into it

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [North America](#north-america)
   * [South America](#south-america)
   * [Zealandia](#zealandia)
+* [Dropper tools](#dropper-tools)
 * [Exfiltration Tools](#exfiltration-tools)
 * [Exploit Development Tools](#exploit-development-tools)
 * [File Format Analysis Tools](#file-format-analysis-tools)
@@ -227,6 +228,10 @@ See [awesome-malware-analysis § Books](https://github.com/rshipp/awesome-malwar
 ### Zealandia
 
 * [CHCon](https://chcon.nz) - Christchurch Hacker Con, Only South Island of New Zealand hacker con.
+
+## Dropper Tools
+
+* [curlNexec](https://github.com/ariary/curlNexec) - Curl & exec binary file in one step. Binary file not be mapped into the file system. Cover execution tracks with fake program execution name. Bypass firewall with HTTP3 protocol support(aka quic)
 
 ## Exfiltration Tools
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
   * [North America](#north-america)
   * [South America](#south-america)
   * [Zealandia](#zealandia)
-* [Dropper tools](#dropper-tools)
+* [Dropper Tools](#dropper-tools)
 * [Exfiltration Tools](#exfiltration-tools)
 * [Exploit Development Tools](#exploit-development-tools)
 * [File Format Analysis Tools](#file-format-analysis-tools)


### PR DESCRIPTION
**What is dropper tools category?** 
> A dropper is a kind of Trojan that has been designed to "install" some sort of malware (virus, backdoor, etc.) to a target system.

I think this kind of tools could not be placed into other category and are part of the arsenal of a pentester

**What is curlNexec?**
`curlNexec` could be used as a stealth dropper (for Unix). It enable us to retrieve a remote binary file and execute it in one step. 
* The binary file is not mapped into the host file system
* The execution program name could be customizable
* Bypass 3rd generation  firewall could be done with `http3` support