### PR TITLE
Add RAT category and add fileless-xec into it

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Your contributions and suggestions are heartily♥ welcome. (✿◕‿◕). Plea
 * [Physical Access Tools](#physical-access-tools)
 * [Privilege Escalation Tools](#privilege-escalation-tools)
   * [Password Spraying Tools](#password-spraying-tools)
+* [Remote Access Trojan (RAT) tools](#remote-access-trojan-rat-tools)
 * [Reverse Engineering](#reverse-engineering)
   * [Reverse Engineering Books](#reverse-engineering-books)
   * [Reverse Engineering Tools](#reverse-engineering-tools)
@@ -671,6 +672,10 @@ See also *[Web-accessible source code ripping tools](#web-accessible-source-code
 
 * [DomainPasswordSpray](https://github.com/dafthack/DomainPasswordSpray) - Tool written in PowerShell to perform a password spray attack against users of a domain.
 * [SprayingToolkit](https://github.com/byt3bl33d3r/SprayingToolkit) - Scripts to make password spraying attacks against Lync/S4B, Outlook Web Access (OWA) and Office 365 (O365) a lot quicker, less painful and more efficient.
+
+## Remote Access Trojan (RAT) tools
+
+* [fileless-xec](https://github.com/ariary/fileless-xec) - Stealth dropper to execute remote binaries without dropping them on disk. HTTP3/ICMP support, Windows support.
 
 ## Reverse Engineering
 


### PR DESCRIPTION
**What is RAT tools category?** 
> A remote access Trojan (RAT) is a malware program that includes a back door for administrative control over the target computer.

I think this kind of tools could not be placed into other category and are part of the arsenal of a pentester. 

**What is fileless-xec?**
`fileless-xec` could be used as a stealth dropper (kind of trojan that has been designed to "install" some sort of malware to a target system). It enable us to retrieve a remote binary file and execute it in one step without dropping binary on disk. 
* The binary file is not mapped into the host file system
* The execution program name could be customizable
* Bypass 3rd generation  firewall could be done with `http3` support
* Bypass network restriction with icmp support
* Handle different type of connection with remote (client or server)