### PR TITLE
add tlsmate to Transport Layer Security Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,6 +441,7 @@ See also *[Intercepting Web proxies](#intercepting-web-proxies)*.
 * [crackpkcs12](https://github.com/crackpkcs12/crackpkcs12) - Multithreaded program to crack PKCS#12 files (`.p12` and `.pfx` extensions), such as TLS/SSL certificates.
 * [testssl.sh](https://github.com/drwetter/testssl.sh) - Command line tool which checks a server's service on any port for the support of TLS/SSL ciphers, protocols as well as some cryptographic flaws.
 * [tls_prober](https://github.com/WestpointLtd/tls_prober) - Fingerprint a server's SSL/TLS implementation.
+* [tlsmate](https://gitlab.com/guballa/tlsmate) - Framework to create arbitrary TLS test cases. Comes with a TLS server scanner plugin.
 
 ### Wireless Network Tools
 


### PR DESCRIPTION
tlsmate is a framework to create arbitrary TLS test cases. Comes with a TLS server scanner plugin.