### PR TITLE
Added Embeddedsw.net to `Steganography Tools`

### DIFF
--- a/README.md
+++ b/README.md
@@ -788,6 +788,7 @@ See also [awesome-social-engineering](https://github.com/v2-dev/awesome-social-e
 * [Cloakify](https://github.com/TryCatchHCF/Cloakify) - Textual steganography toolkit that converts any filetype into lists of everyday strings.
 * [StegOnline](https://stegonline.georgeom.net/) - Web-based, enhanced, and open-source port of StegSolve.
 * [StegCracker](https://github.com/Paradoxis/StegCracker) - Steganography brute-force utility to uncover hidden data inside files.
+* [Embeddedsw](https://embeddedsw.net/) - Collection of tools related to Steganography, Cryptography and Obfuscation.
 
 ## Vulnerability Databases
 


### PR DESCRIPTION
I Added Embeddedsw.net to `Steganography Tools` - A Website providing tools related to Steganography, Cryptography and Obfuscation.


## Contains
- https://embeddedsw.net/
- https://embeddedsw.net/Cipher_Reference_Home.html
- https://embeddedsw.net/libObfuscate_Cryptography_Home.html
- https://embeddedsw.net/MultiObfuscator_Cryptography_Home.html
- https://embeddedsw.net/OpenPuff_Steganography_Home.html
- https://embeddedsw.net/Randomness_Test_Home.html

and more, such as resources, tests, data and other links.
***
Screenshot is provided below.
![image](https://github.com/enaqx/awesome-pentest/assets/68499986/98582fec-05e9-4b7c-9a58-2d3958dd9b89)
