### PR TITLE
Add OpalOPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ See also [awesome-industrial-control-system-security](https://github.com/hslatma
 
 * [Industrial Exploitation Framework (ISF)](https://github.com/dark-lbp/isf) - Metasploit-like exploit framework based on routersploit designed to target Industrial Control Systems (ICS), SCADA devices, PLC firmware, and more.
 * [s7scan](https://github.com/klsecservices/s7scan) - Scanner for enumerating Siemens S7 PLCs on a TCP/IP or LLC network.
+* [OpalOPC](https://opalopc.com/) - Commercial OPC UA vulnerability assessment tool, sold by Molemmat.
 
 ## Intentionally Vulnerable Systems
 
@@ -473,7 +474,6 @@ See also *[Intercepting Web proxies](#intercepting-web-proxies)*.
 * [Nexpose](https://www.rapid7.com/products/nexpose/) - Commercial vulnerability and risk management assessment engine that integrates with Metasploit, sold by Rapid7.
 * [OpenVAS](http://www.openvas.org/) - Free software implementation of the popular Nessus vulnerability assessment system.
 * [Vuls](https://github.com/future-architect/vuls) - Agentless vulnerability scanner for GNU/Linux and FreeBSD, written in Go.
-* [OpalOPC](https://opalopc.com/) - Commercial OPC UA vulnerability assessment tool, sold by Molemmat.
 
 ### Web Vulnerability Scanners
 

--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ See also *[Intercepting Web proxies](#intercepting-web-proxies)*.
 * [Nexpose](https://www.rapid7.com/products/nexpose/) - Commercial vulnerability and risk management assessment engine that integrates with Metasploit, sold by Rapid7.
 * [OpenVAS](http://www.openvas.org/) - Free software implementation of the popular Nessus vulnerability assessment system.
 * [Vuls](https://github.com/future-architect/vuls) - Agentless vulnerability scanner for GNU/Linux and FreeBSD, written in Go.
+* [OpalOPC](https://opalopc.com/) - Commercial OPC UA vulnerability assessment tool, sold by Molemmat.
 
 ### Web Vulnerability Scanners
 


### PR DESCRIPTION
OpalOPC is a vulnerability scanner developed by myself. It targets the OT protocol OPC UA. It is free for non-commercial use.