### PR TITLE
Updated Reconmap URL from org to com

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ See also *[HackingThe.cloud](https://hackingthe.cloud/)*.
 * [Dradis](https://dradisframework.com) - Open-source reporting and collaboration tool for IT security professionals.
 * [Lair](https://github.com/lair-framework/lair/wiki) - Reactive attack collaboration framework and web application built with meteor.
 * [Pentest Collaboration Framework (PCF)](https://gitlab.com/invuls/pentest-projects/pcf) - Open source, cross-platform, and portable toolkit for automating routine pentest processes with a team.
-* [Reconmap](https://reconmap.org/) - Open-source collaboration platform for InfoSec professionals that streamlines the pentest process.
+* [Reconmap](https://reconmap.com/) - Open-source collaboration platform for InfoSec professionals that streamlines the pentest process.
 * [RedELK](https://github.com/outflanknl/RedELK) - Track and alarm about Blue Team activities while providing better usability in long term offensive operations.
 
 ## Conferences and Events


### PR DESCRIPTION
Reconmap's URL changed from .org to .com, so I have updated it accordingly, since there is no redirect on the .org domain.