### PR TITLE
Update Dradis website link to reflect new domain used

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ See also *[HackingThe.cloud](https://hackingthe.cloud/)*.
 
 ## Collaboration Tools
 
-* [Dradis](https://dradisframework.com) - Open-source reporting and collaboration tool for IT security professionals.
+* [Dradis](https://dradis.com/) - Open-source reporting and collaboration tool for IT security professionals.
 * [Hexway Hive](https://hexway.io/hive/) - Commercial collaboration, data aggregation, and reporting framework for red teams with a limited free self-hostable option.
 * [Lair](https://github.com/lair-framework/lair/wiki) - Reactive attack collaboration framework and web application built with meteor.
 * [Pentest Collaboration Framework (PCF)](https://gitlab.com/invuls/pentest-projects/pcf) - Open source, cross-platform, and portable toolkit for automating routine pentest processes with a team.


### PR DESCRIPTION
Update to Dradis website link to reflect the new domain they are using