### PR TITLE
Add `ronin-exploits` to the Exploit Development Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,7 @@ See also *[Reverse Engineering Tools](#reverse-engineering-tools)*.
 * [H26Forge](https://github.com/h26forge/h26forge) - Domain-specific infrastructure for analyzing, generating, and manipulating syntactically correct but semantically spec-non-compliant video files.
 * [Magic Unicorn](https://github.com/trustedsec/unicorn) - Shellcode generator for numerous attack vectors, including Microsoft Office macros, PowerShell, HTML applications (HTA), or `certutil` (using fake certificates).
 * [Pwntools](https://github.com/Gallopsled/pwntools) - Rapid exploit development framework built for use in CTFs.
+* [ronin-exploits](https://github.com/ronin-rb/ronin-exploits#readme) - Ruby micro-framework for writing and running exploits and payloads.
 * [Wordpress Exploit Framework](https://github.com/rastating/wordpress-exploit-framework) - Ruby framework for developing and using modules which aid in the penetration testing of WordPress powered websites and systems.
 * [peda](https://github.com/longld/peda) - Python Exploit Development Assistance for GDB.
 


### PR DESCRIPTION
While [Ronin](https://ronin-rb.dev) was already added to the Multi-Paradigm Frameworks section, I thought [ronin-exploits](https://github.com/ronin-rb/ronin-exploits#readme) (included in Ronin, but can be installed separately) also belongs under Exploit Development Tools.