### PR TITLE
Add `ronin-recon` to the Network Reconnaissance Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ See [awesome-lockpicking](https://github.com/fabacab/awesome-lockpicking).
 * [nmap](https://nmap.org/) - Free security scanner for network exploration & security audits.
 * [passivedns-client](https://github.com/chrislee35/passivedns-client) - Library and query tool for querying several passive DNS providers.
 * [passivedns](https://github.com/gamelinux/passivedns) - Network sniffer that logs all DNS server replies for use in a passive DNS setup.
+* [ronin-recon](https://github.com/ronin-rb/ronin-recon#readme) - Micro-framework and tool for performing reconnaissance.
 * [RustScan](https://github.com/rustscan/rustscan) - Lightweight and quick open-source port scanner designed to automatically pipe open ports into Nmap.
 * [scanless](https://github.com/vesche/scanless) - Utility for using websites to perform port scans on your behalf so as not to reveal your own IP.
 * [smbmap](https://github.com/ShawnDEvans/smbmap) - Handy SMB enumeration tool.


### PR DESCRIPTION
While [Ronin](https://ronin-rb.dev) is already added to the Multi-Paradigm Frameworks section, I thought [ronin-recon](https://github.com/ronin-rb/ronin-recon#readme) (included in Ronin, but can be installed separately) also belongs under the Network Reconnaissance Tools section.