### PR TITLE
[Pull Request] Adding friTap as SSL/TLS decryption framework/toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,6 +443,7 @@ See also *[Intercepting Web proxies](#intercepting-web-proxies)*.
 * [oregano](https://github.com/nametoolong/oregano) - Python module that runs as a machine-in-the-middle (MITM) accepting Tor client requests.
 * [sylkie](https://dlrobertson.github.io/sylkie/) - Command line tool and library for testing networks for common address spoofing security vulnerabilities in IPv6 networks using the Neighbor Discovery Protocol.
 * [PETEP](https://github.com/Warxim/petep) - Extensible TCP/UDP proxy with GUI for traffic analysis & modification with SSL/TLS support.
+* [friTap](https://github.com/fkie-cad/friTap) - Intercept SSL/TLS connections with frida; Allows TLS key extraction and decryption of TLS payload as PCAP in real time.
 
 ### Transport Layer Security Tools
 


### PR DESCRIPTION
Pull request to add friTap. friTap is a tool for simplifying SSL/TLS traffic analysis for researchers and pentesters by making SSL decryption effortless. It allows TLS key extraction and the decryption of TLS payload as PCAP in real time.