### PR TITLE
Add LeakRadar to breach intelligence tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ See also [awesome-osint](https://github.com/jivoi/awesome-osint).
 * [Threat Crowd](https://www.threatcrowd.org/) - Search engine for threats.
 * [Virus Total](https://www.virustotal.com/) - Free service that analyzes suspicious files and URLs and facilitates the quick detection of viruses, worms, trojans, and all kinds of malware.
 * [surfraw](https://github.com/kisom/surfraw) - Fast UNIX command line interface to a variety of popular WWW search engines.
+* [LeakRadar](https://leakradar.io/) - Breach intelligence search engine indexing 220B+ credentials from stealer logs and data breaches. Provides domain breach reports with exposed employee credentials, dark web monitoring, and API access.
 
 ### Dorking tools
 


### PR DESCRIPTION
Adding LeakRadar to the OSINT Data Broker and Search Engine Services section.